### PR TITLE
feat(services): UI improvements - notices, partner history card, filters redesign

### DIFF
--- a/backend/src/main/java/com/rideops/identity/application/admin/ListUserAdminAuditLogUseCase.java
+++ b/backend/src/main/java/com/rideops/identity/application/admin/ListUserAdminAuditLogUseCase.java
@@ -14,7 +14,7 @@ public class ListUserAdminAuditLogUseCase {
     }
 
     public List<UserAdminAuditLogDto> execute(LocalDate dateFilter, String adminUserIdFilter) {
-        return userAdminAuditLogPort.findLatest(20, dateFilter, adminUserIdFilter)
+        return userAdminAuditLogPort.findLatest(10, dateFilter, adminUserIdFilter)
             .stream()
             .map(entry -> new UserAdminAuditLogDto(
                 entry.getId(),

--- a/backend/src/main/java/com/rideops/identity/application/admin/ListUsersUseCase.java
+++ b/backend/src/main/java/com/rideops/identity/application/admin/ListUsersUseCase.java
@@ -1,6 +1,6 @@
 package com.rideops.identity.application.admin;
 
-import com.rideops.multitenancy.application.TenantManagementRepositoryPort;
+import com.rideops.multitenancy.TenantRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,16 +11,16 @@ import java.util.stream.Collectors;
 public class ListUsersUseCase {
 
     private final UserAdminRepositoryPort userAdminRepositoryPort;
-    private final TenantManagementRepositoryPort tenantManagementRepositoryPort;
+    private final TenantRepository tenantRepository;
 
     public ListUsersUseCase(UserAdminRepositoryPort userAdminRepositoryPort,
-                            TenantManagementRepositoryPort tenantManagementRepositoryPort) {
+                            TenantRepository tenantRepository) {
         this.userAdminRepositoryPort = userAdminRepositoryPort;
-        this.tenantManagementRepositoryPort = tenantManagementRepositoryPort;
+        this.tenantRepository = tenantRepository;
     }
 
     public List<UserSummaryDto> execute() {
-        Map<Long, String> tenantNames = tenantManagementRepositoryPort.findAllByOrderByBusinessNameAsc()
+        Map<Long, String> tenantNames = tenantRepository.findAll()
             .stream()
             .collect(Collectors.toMap(t -> t.getId(), t -> t.getBusinessName()));
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -162,19 +162,32 @@ a:hover {
 /* === Notice banner (info / errore / successo) === */
 .services-notice {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 11px 14px;
-  border-radius: 10px;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 20px 22px;
+  border-radius: 14px;
   margin-bottom: 12px;
-  font-size: 14px;
-  line-height: 1.4;
+  font-size: 16px;
+  line-height: 1.45;
+  border: 1px solid transparent;
 }
 
 .services-notice--error {
   background: #fdecea;
   border: 1px solid #f5c6c2;
   color: #b71c1c;
+}
+
+.services-notice--warning {
+  background: #fff4df;
+  border-color: #f2d39a;
+  color: #8a4b00;
+}
+
+.services-notice--info {
+  background: #eef4fa;
+  border-color: #bdd8f2;
+  color: #1f2a3b;
 }
 
 .services-notice--success {
@@ -185,8 +198,8 @@ a:hover {
 
 .services-notice-icon {
   flex-shrink: 0;
-  width: 20px;
-  height: 20px;
+  width: 30px;
+  height: 30px;
   display: grid;
   place-items: center;
 }
@@ -199,6 +212,16 @@ a:hover {
 
 .services-notice-text {
   flex: 1;
+  display: grid;
+  gap: 4px;
+}
+
+.services-notice-title {
+  display: block;
+  font-size: 18px;
+  font-size: clamp(16px, 1.4vw, 20px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
 }
 
 .services-notice-close {
@@ -217,6 +240,241 @@ a:hover {
 
 .services-notice-close:hover {
   opacity: 1;
+}
+
+/* ── Storico partner servizio (sph) ─────────────────────────── */
+.sph-card {
+  margin-top: 18px;
+}
+
+/* header */
+.sph-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.sph-header-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.sph-header-icon {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  color: var(--primary, #1565c0);
+}
+.sph-header-icon svg {
+  width: 100%;
+  height: 100%;
+}
+.sph-header-label {
+  font-size: clamp(15px, 1.2vw, 18px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text, #1f2a3b);
+}
+.sph-comm-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 13px;
+  border-radius: 999px;
+  background: #e8edf3;
+  color: #4a5568;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* meta row: partner + email */
+.sph-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 0;
+  padding: 12px 16px;
+  background: #f8fafc;
+  border-radius: 10px;
+  margin-bottom: 16px;
+}
+.sph-meta-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 1;
+  min-width: 180px;
+}
+.sph-meta-sep {
+  width: 1px;
+  height: 24px;
+  background: #d0dae7;
+  flex-shrink: 0;
+  margin: 0 16px;
+}
+.sph-meta-icon {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  color: var(--primary, #1565c0);
+}
+.sph-meta-icon svg {
+  width: 100%;
+  height: 100%;
+}
+.sph-meta-key {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  color: #8898aa;
+  text-transform: uppercase;
+}
+.sph-meta-val {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a2b45;
+  word-break: break-all;
+}
+.sph-meta-link {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1565c0;
+  text-decoration: none;
+  word-break: break-all;
+}
+.sph-meta-link:hover {
+  text-decoration: underline;
+}
+
+/* divider */
+.sph-divider {
+  height: 1px;
+  background: #e2e8f0;
+  margin-bottom: 16px;
+}
+
+/* table */
+.sph-table-wrap {
+  overflow-x: auto;
+}
+.sph-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+  font-size: 14px;
+}
+.sph-th {
+  padding: 9px 14px;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: #7a8ea5;
+  text-transform: uppercase;
+  border-bottom: 1.5px solid #e2e8f0;
+  white-space: nowrap;
+}
+.sph-th--subject { width: 40%; }
+.sph-th--date { white-space: nowrap; }
+.sph-tr:not(:last-child) .sph-td {
+  border-bottom: 1px solid #edf1f6;
+}
+.sph-td {
+  padding: 10px 14px;
+  color: #2d3e50;
+  vertical-align: middle;
+}
+.sph-td--subject { color: #4a5568; }
+.sph-td--date { white-space: nowrap; color: #64748b; font-size: 13px; }
+
+/* channel badge */
+.sph-channel-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 11px;
+  border-radius: 999px;
+  background: #1976d2;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* empty state */
+.sph-empty {
+  margin: 8px 0 12px;
+  color: #8898aa;
+  font-size: 14px;
+}
+
+/* footer actions */
+.sph-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid #e2e8f0;
+}
+.sph-send-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 20px;
+  border: 1.5px solid var(--primary, #1565c0);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--primary, #1565c0);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.sph-send-btn:hover:not(:disabled) {
+  background: var(--primary, #1565c0);
+  color: #fff;
+}
+.sph-send-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.sph-send-icon {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 17px;
+  height: 17px;
+}
+.sph-send-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 900px) {
+  .sph-header {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+  .sph-meta-sep {
+    display: none;
+  }
+  .sph-meta-item {
+    min-width: 100%;
+  }
+  .sph-actions {
+    justify-content: stretch;
+  }
+  .sph-send-btn {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 .warning-text {
@@ -1865,24 +2123,23 @@ a:hover {
 
 .services-row-menu-btn {
   background: transparent;
-  border: 1px solid #d0dcea;
-  border-radius: 8px;
+  border: none;
+  border-radius: 10px;
   width: 32px;
   height: 32px;
   display: grid;
   place-items: center;
-  font-size: 16px;
-  color: #5f7693;
+  font-size: 19px;
+  color: #2a3442;
   cursor: pointer;
-  letter-spacing: 1px;
-  transition: background 0.15s, border-color 0.15s;
+  letter-spacing: 0;
+  transition: background 0.15s, color 0.15s;
   line-height: 1;
 }
 
 .services-row-menu-btn:hover {
-  background: #eaf1f9;
-  border-color: #b0c4dc;
-  color: #2c5a8a;
+  background: #eef2f7;
+  color: #111827;
 }
 
 .services-row-menu-dropdown {
@@ -1891,10 +2148,10 @@ a:hover {
   top: calc(100% + 4px);
   z-index: 100;
   background: #ffffff;
-  border: 1px solid #d0dcea;
-  border-radius: 10px;
-  box-shadow: 0 4px 18px rgba(15, 50, 90, 0.13);
-  min-width: 160px;
+  border: 1px solid #d4dce7;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.14);
+  min-width: 190px;
   overflow: hidden;
 }
 
@@ -1906,7 +2163,7 @@ a:hover {
   padding: 9px 14px;
   background: transparent;
   border: none;
-  font-size: 13.5px;
+  font-size: 15px;
   font-weight: 500;
   color: #2a3442;
   cursor: pointer;
@@ -1924,8 +2181,8 @@ a:hover {
 }
 
 .services-row-menu-item-icon {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   display: inline-grid;
   place-items: center;
   color: currentColor;
@@ -1943,25 +2200,25 @@ a:hover {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  margin-top: 14px;
+  gap: 14px;
+  margin-top: 18px;
   flex-wrap: wrap;
 }
 
 .services-list-footer-size {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  color: #5f7693;
+  gap: 10px;
+  font-size: 14px;
+  color: #6b7f9d;
 }
 
 .services-list-pagesize-select {
-  border: 1px solid #c8d5e4;
-  border-radius: 6px;
-  padding: 3px 6px;
-  font-size: 13px;
-  color: #2a3442;
+  border: 1px solid #d0dcea;
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 15px;
+  color: #334155;
   background: #ffffff;
   cursor: pointer;
 }
@@ -1975,11 +2232,11 @@ a:hover {
 .services-list-page-btn {
   background: transparent;
   border: 1px solid #d0dcea;
-  border-radius: 8px;
-  padding: 4px 10px;
-  font-size: 13px;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 14px;
   font-weight: 600;
-  color: #2c6aad;
+  color: #64748b;
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -1995,10 +2252,225 @@ a:hover {
 }
 
 .services-list-page-info {
-  font-size: 13px;
-  color: #5f7693;
+  font-size: 15px;
+  color: #64748b;
   font-weight: 500;
   white-space: nowrap;
+}
+
+.services-selection-toolbar {
+  margin-top: 10px;
+  border: 1px solid #dbe3ee;
+  border-radius: 12px;
+  background: #f8fafd;
+  padding: 12px 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.services-selection-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.services-selection-count {
+  background: #e6ebf2;
+  color: #1f2937;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.services-selection-total {
+  color: #66758b;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.services-selection-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.services-selection-actions .logout-button.compact-button {
+  min-height: 48px;
+  padding: 10px 16px;
+  font-size: 15px;
+  border-radius: 10px;
+}
+
+.services-table-modern thead th {
+  font-size: 14px;
+  color: #687c96;
+  font-weight: 700;
+  padding-top: 12px !important;
+  padding-bottom: 16px !important;
+}
+
+.services-table-modern thead th:first-child,
+.services-table-modern tbody td:first-child {
+  padding-left: 10px !important;
+}
+
+.services-table-modern tbody td {
+  padding-top: 18px !important;
+  padding-bottom: 18px !important;
+}
+
+.services-table-modern tbody tr {
+  border-bottom: 1px solid #e3eaf3;
+}
+
+.services-table-modern tbody tr:last-child {
+  border-bottom: none;
+}
+
+.services-table-checkbox {
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  accent-color: #2d7de2;
+  cursor: pointer;
+}
+
+.services-table-row.is-selected {
+  background: #edf5ff;
+}
+
+.services-table-ref {
+  color: #6a7b92;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.services-table-datetime {
+  display: grid;
+  gap: 3px;
+  color: #2a3442;
+}
+
+.services-table-datetime strong {
+  font-size: 16px;
+  line-height: 1.05;
+}
+
+.services-table-datetime span {
+  font-size: 14px;
+  color: #60748f;
+}
+
+.services-table-route {
+  display: grid;
+  gap: 6px;
+  min-width: 280px;
+}
+
+.services-table-route-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.services-table-route-icon {
+  width: 16px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  color: #7086a5;
+  flex: 0 0 auto;
+}
+
+.services-table-route-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.services-table-route-text {
+  color: #2a3442;
+  font-size: 15px;
+  line-height: 1.2;
+  max-width: 370px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.service-chip-type-neutral {
+  background: #f7f8fa;
+  border: 1px solid #d0d7e2;
+  color: #2a3442;
+  font-size: 14px;
+  padding: 5px 14px;
+}
+
+.services-table-driver-vehicle {
+  display: grid;
+  gap: 4px;
+}
+
+.services-table-driver-vehicle strong {
+  color: #1f2937;
+  font-size: 16px;
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.services-table-driver-vehicle > span {
+  color: #6d7f97;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.services-table-driver-vehicle-icon {
+  width: 14px;
+  height: 14px;
+  display: inline-grid;
+  place-items: center;
+}
+
+.services-table-driver-vehicle-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.services-table-price {
+  color: #1f2937;
+  font-size: 16px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.service-chip-status-pill {
+  font-size: 14px;
+  padding: 6px 14px;
+  border: none;
+  color: #ffffff;
+}
+
+.service-chip-status-pill.assigned {
+  background: #22a3e7;
+}
+
+.service-chip-status-pill.open {
+  background: #f18809;
+}
+
+.service-chip-status-pill.closed {
+  background: #2fa55b;
+}
+
+.service-chip-status-pill.executed {
+  background: #fb923c;
 }
 
 /* === Service chip — base (global) === */
@@ -2046,30 +2518,34 @@ a:hover {
 
 /* === Services filters card === */
 .services-filters-card {
-  padding: 16px 20px;
-  margin-top: 12px;
+  padding: 18px 26px;
+  margin-top: 0;
+  border: 1px solid #d9e1eb;
+  border-radius: 14px;
+  background: #f8fafc;
+}
+
+.services-filters-panel {
+  display: grid;
+  gap: 14px;
 }
 
 .services-filters-row {
   display: flex;
   align-items: flex-end;
-  gap: 10px;
+  gap: 14px;
   flex-wrap: wrap;
 }
 
-.services-search-wrap {
-  flex: 1 1 240px;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.services-filters-row-secondary {
+  padding-top: 6px;
 }
 
-.services-search-wrap::before {
-  content: '\00a0';
-  display: block;
-  font-size: 11.5px;
-  font-weight: 600;
-  line-height: 1.4;
+.services-search-wrap {
+  flex: 1 1 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .services-search-input-wrap {
@@ -2104,10 +2580,11 @@ a:hover {
 
 .services-search-input {
   width: 100%;
-  padding: 9px 12px 9px 36px;
+  min-height: 58px;
+  padding: 12px 16px 12px 56px;
   border: 1.5px solid #d0dcea;
-  border-radius: 10px;
-  font-size: 14px;
+  border-radius: 14px;
+  font-size: 17px;
   color: #1e2d3d;
   background: #ffffff;
   outline: none;
@@ -2126,35 +2603,49 @@ a:hover {
 .services-filter-group {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 8px;
   flex: 0 0 auto;
 }
 
+.services-filter-group--status,
+.services-filter-group--driver,
+.services-filter-group--type {
+  min-width: 200px;
+}
+
 .services-filter-label {
-  font-size: 11.5px;
+  font-size: 15px;
   font-weight: 600;
-  color: #6e84a0;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  color: #6b7f9d;
   padding-left: 2px;
 }
 
-.services-filter-select {
+.services-filter-select,
+.services-filter-input {
   border: 1.5px solid #d0dcea;
-  border-radius: 10px;
-  padding: 8px 32px 8px 12px;
-  font-size: 14px;
+  border-radius: 14px;
+  min-height: 58px;
+  padding: 12px 44px 12px 18px;
+  font-size: 17px;
   color: #1e2d3d;
-  background: #ffffff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24'%3E%3Cpath d='M6 9l6 6 6-6' fill='none' stroke='%236e84a0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat right 10px center;
+  background: #ffffff;
+  outline: none;
+  min-width: 180px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  box-sizing: border-box;
+}
+
+.services-filter-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24'%3E%3Cpath d='M6 9l6 6 6-6' fill='none' stroke='%236e84a0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
   -webkit-appearance: none;
   appearance: none;
   cursor: pointer;
-  outline: none;
-  min-width: 110px;
-  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.services-filter-select:focus {
+.services-filter-select:focus,
+.services-filter-input:focus {
   border-color: #1e88e5;
   box-shadow: 0 0 0 3px rgba(30, 136, 229, 0.12);
 }
@@ -2162,14 +2653,15 @@ a:hover {
 .services-filter-unassigned-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
+  gap: 10px;
+  min-height: 58px;
+  padding: 12px 18px;
   border: 1.5px solid #d0dcea;
-  border-radius: 10px;
+  border-radius: 14px;
   background: #ffffff;
-  font-size: 13.5px;
+  font-size: 17px;
   font-weight: 600;
-  color: #3d5a75;
+  color: #2b3648;
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
@@ -2187,8 +2679,8 @@ a:hover {
 }
 
 .services-filter-unassigned-icon {
-  width: 15px;
-  height: 15px;
+  width: 20px;
+  height: 20px;
   display: grid;
   place-items: center;
 }
@@ -2203,21 +2695,23 @@ a:hover {
 .services-active-filters-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 12px;
+  gap: 10px;
+  margin-top: 2px;
+  padding-top: 14px;
+  border-top: 1px solid #e7edf5;
   flex-wrap: wrap;
 }
 
 .services-active-filters-label {
-  font-size: 12.5px;
-  color: #6e84a0;
+  font-size: 14px;
+  color: #6b7f9d;
   font-weight: 600;
   white-space: nowrap;
 }
 
 .services-active-chips {
   display: flex;
-  gap: 6px;
+  gap: 8px;
   flex-wrap: wrap;
   flex: 1;
 }
@@ -2225,14 +2719,29 @@ a:hover {
 .services-active-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  background: #edf3fb;
-  border: 1px solid #c4d7ed;
+  gap: 8px;
+  background: #eef2f6;
+  border: 1px solid #d7dfe8;
   border-radius: 999px;
-  padding: 3px 8px 3px 10px;
-  font-size: 12.5px;
+  padding: 6px 10px 6px 14px;
+  font-size: 14px;
   font-weight: 600;
-  color: #2c5a8a;
+  color: #2b3648;
+}
+
+.services-active-chip-icon {
+  width: 16px;
+  height: 16px;
+  display: grid;
+  place-items: center;
+  color: #6e84a0;
+  flex: 0 0 auto;
+}
+
+.services-active-chip-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .services-active-chip-remove {
@@ -2259,8 +2768,8 @@ a:hover {
   background: transparent;
   border: none;
   cursor: pointer;
-  color: #1e88e5;
-  font-size: 13px;
+  color: #6b7f9d;
+  font-size: 14px;
   font-weight: 600;
   padding: 2px 0;
   white-space: nowrap;
@@ -3076,6 +3585,46 @@ a:hover {
     font-weight: 600;
     font-size: 16px;
     cursor: pointer;
+  }
+
+  .services-filters-card {
+    padding: 16px;
+  }
+
+  .services-filters-panel {
+    gap: 12px;
+  }
+
+  .services-filters-row {
+    gap: 12px;
+  }
+
+  .services-search-wrap,
+  .services-filter-group {
+    flex: 1 1 100%;
+  }
+
+  .services-filter-group--status,
+  .services-filter-group--driver,
+  .services-filter-group--type {
+    min-width: 0;
+  }
+
+  .services-filter-select,
+  .services-filter-input,
+  .services-filter-unassigned-btn,
+  .services-search-input {
+    min-width: 0;
+    width: 100%;
+    font-size: 16px;
+  }
+
+  .services-active-filters-row {
+    align-items: flex-start;
+  }
+
+  .services-reset-link {
+    margin-left: 0;
   }
 
   .services-filters-grid.is-hidden-mobile {

--- a/frontend/components/admin-users-panel.tsx
+++ b/frontend/components/admin-users-panel.tsx
@@ -215,7 +215,7 @@ export function AdminUsersPanel() {
             </select>
           </label>
           <label>
-            Cliente
+            Tenant
             <input className="form-input" value={filterTenant} onChange={(e) => setFilterTenant(e.target.value)} placeholder="cerca..." />
           </label>
         </div>
@@ -237,7 +237,7 @@ export function AdminUsersPanel() {
                     <th align="left">User ID</th>
                     <th align="left">Email</th>
                     <th align="left">Ruolo</th>
-                    <th align="left">Cliente</th>
+                    <th align="left">Tenant</th>
                     <th align="left">Stato</th>
                     <th align="left">Data Creazione</th>
                     <th align="left">Azioni</th>
@@ -283,7 +283,7 @@ export function AdminUsersPanel() {
                   </div>
                   <div className="admin-user-email">{user.email}</div>
                   {user.tenantName && (
-                    <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary, #888)', marginBottom: 4 }}>Cliente: {user.tenantName}</div>
+                    <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary, #888)', marginBottom: 4 }}>Tenant: {user.tenantName}</div>
                   )}
                   <div className="admin-user-card-footer">
                     <div className="admin-user-meta">

--- a/frontend/components/services-panel.tsx
+++ b/frontend/components/services-panel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { FormEvent, ReactNode, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { createPortal } from 'react-dom';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { AddIcon, ArrowLeftIcon, ArrowRightIcon, ButtonContent, CancelIcon, CursorIcon, LockIcon, OpenIcon, PartnerIcon as SharedPartnerIcon, PrintIcon as SharedPrintIcon, ResetIcon, SaveIcon, SelectIcon } from './action-icons';
+import { AddIcon, ArrowLeftIcon, ArrowRightIcon, ButtonContent, CalendarIcon, CancelIcon, CursorIcon, FilterIcon, LockIcon, OpenIcon, PartnerIcon as SharedPartnerIcon, PrintIcon as SharedPrintIcon, ResetIcon, SaveIcon, SearchIcon, SelectIcon, UserIcon } from './action-icons';
 import { formatCurrencyEUR } from '../lib/currency';
 
 type ServiceType = 'TRANSFER' | 'TOUR';
@@ -107,12 +107,16 @@ type VehicleItem = {
 };
 
 type ServicesFilterState = {
+  query: string;
   status: ServiceStatus | '';
   driverId: number | '';
   type: ServiceType | '';
-  search: string;
+  fromDate: string;
+  toDate: string;
   onlyUnassigned: boolean;
 };
+
+type ServiceNoticeTone = 'info' | 'warning' | 'error';
 
 const defaultForm: ServiceFormState = {
   startAt: '',
@@ -141,12 +145,31 @@ const vehicleDayConflictMessage = 'Il veicolo risulta già assegnato ad un altro
 const vehicleMaintenanceConflictMessage = 'Il veicolo risulta in manutenzione nella giornata del servizio';
 
 const defaultFilters: ServicesFilterState = {
+  query: '',
   status: '',
   driverId: '',
   type: '',
-  search: '',
+  fromDate: '',
+  toDate: '',
   onlyUnassigned: false
 };
+
+function formatFilterDate(dateValue: string) {
+  if (!dateValue) {
+    return '';
+  }
+
+  const parsedDate = new Date(`${dateValue}T00:00:00`);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return dateValue;
+  }
+
+  return new Intl.DateTimeFormat('it-IT', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+  }).format(parsedDate);
+}
 
 function MobileClockIcon() {
   return (
@@ -249,41 +272,6 @@ function ServiceDetailRow({ icon, label, value }: { icon: ReactNode; label: stri
   );
 }
 
-function SearchIcon() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <circle cx="11" cy="11" r="6.5" fill="none" stroke="currentColor" strokeWidth="1.8" />
-      <line x1="16.2" y1="16.2" x2="21" y2="21" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function FilterIcon() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 6h16M7 12h10M10 18h4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function EyeIcon() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
-      <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" strokeWidth="1.8" />
-    </svg>
-  );
-}
-
-function DestFlagIcon() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M6 21V4" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-      <path d="M6 4h10l-3.5 4 3.5 4H6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
 function ActionEditIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -342,6 +330,44 @@ function ActionDeselectIcon() {
   );
 }
 
+function ActionViewIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M2.5 12s3.7-6 9.5-6 9.5 6 9.5 6-3.7 6-9.5 6-9.5-6-9.5-6Z" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinejoin="round" />
+      <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" strokeWidth="1.9" />
+    </svg>
+  );
+}
+
+function ServiceNoticeIcon({ tone }: { tone: ServiceNoticeTone }) {
+  if (tone === 'error') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.9" />
+        <path d="M9 9l6 6M15 9l-6 6" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  if (tone === 'warning') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M12 3.5 2.8 19.5h18.4L12 3.5Z" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinejoin="round" />
+        <path d="M12 9v5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+        <circle cx="12" cy="17.2" r="1" fill="currentColor" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.9" />
+      <path d="M12 10.2v6" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+      <circle cx="12" cy="7.2" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function ServicesPanel() {
   function driverLabel(driver: DriverItem) {
     const fullName = [driver.firstName, driver.lastName].filter(Boolean).join(' ').trim();
@@ -351,9 +377,8 @@ export function ServicesPanel() {
     return driver.email;
   }
 
+  const PAGE_SIZE = 25;
   const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
 
   const [services, setServices] = useState<ServiceItem[]>([]);
   const [drivers, setDrivers] = useState<DriverItem[]>([]);
@@ -363,7 +388,6 @@ export function ServicesPanel() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-  const [noticeServiceId, setNoticeServiceId] = useState<number | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editingInitialStatus, setEditingInitialStatus] = useState<Exclude<ServiceStatus, 'CLOSED' | 'EXECUTED'>>('OPEN');
   const [editingInitialAssignedDriverId, setEditingInitialAssignedDriverId] = useState<number | null>(null);
@@ -371,8 +395,6 @@ export function ServicesPanel() {
   const [selectedServiceId, setSelectedServiceId] = useState<number | null>(null);
   const [selectedForPrintIds, setSelectedForPrintIds] = useState<number[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState(25);
-  const [openDropdownId, setOpenDropdownId] = useState<number | null>(null);
   const [outsourceOpen, setOutsourceOpen] = useState(false);
   const [outsourcePartnerQuery, setOutsourcePartnerQuery] = useState('');
   const [outsourcePartnerId, setOutsourcePartnerId] = useState<number | ''>('');
@@ -380,6 +402,9 @@ export function ServicesPanel() {
   const [partnerHistory, setPartnerHistory] = useState<ServicePartnerHistoryItem | null>(null);
   const [partnerHistoryLoading, setPartnerHistoryLoading] = useState(false);
   const [partnerEmailSending, setPartnerEmailSending] = useState(false);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [newButtonPortalTarget, setNewButtonPortalTarget] = useState<HTMLElement | null>(null);
+  const [rowMenuServiceId, setRowMenuServiceId] = useState<number | null>(null);
   const [filters, setFilters] = useState<ServicesFilterState>(defaultFilters);
   const [form, setForm] = useState<ServiceFormState>(defaultForm);
 
@@ -462,6 +487,21 @@ export function ServicesPanel() {
     return `${year}-${month}-${date}T00:00:00`;
   }
 
+  function clearFeedbackNotice() {
+    setError(null);
+    setSuccess(null);
+  }
+
+  function selectService(serviceId: number | null) {
+    setSelectedServiceId(serviceId);
+    clearFeedbackNotice();
+  }
+
+  function updateFilters(next: (prev: ServicesFilterState) => ServicesFilterState) {
+    clearFeedbackNotice();
+    setFilters(next);
+  }
+
   async function loadDrivers() {
     const response = await fetch('/api/gestionale/drivers', { cache: 'no-store' });
     const payload = (await response.json().catch(() => [])) as DriverItem[] | { message?: string };
@@ -511,6 +551,12 @@ export function ServicesPanel() {
     if (filters.driverId) {
       query.set('driverId', String(filters.driverId));
     }
+    if (filters.fromDate) {
+      query.set('from', toStartDateTime(filters.fromDate));
+    }
+    if (filters.toDate) {
+      query.set('to', toNextDayStartDateTime(filters.toDate));
+    }
 
     const targetUrl = query.size > 0 ? `/api/services?${query.toString()}` : '/api/services';
 
@@ -524,11 +570,11 @@ export function ServicesPanel() {
     }
 
     const nextServices = payload as ServiceItem[];
-    const unassignedFiltered = filters.onlyUnassigned
+    const filteredServices = filters.onlyUnassigned
       ? nextServices.filter((service) => !service.assignedDriverId)
       : nextServices;
 
-    setServices(unassignedFiltered);
+    setServices(filteredServices);
     setLoading(false);
   }
 
@@ -548,23 +594,10 @@ export function ServicesPanel() {
     });
   }, [searchParams]);
 
-  function setUnassignedFilter(active: boolean) {
-    const params = new URLSearchParams(searchParams.toString());
-    if (active) {
-      params.set('unassigned', '1');
-    } else {
-      params.delete('unassigned');
-    }
-    router.replace(`${pathname}?${params.toString()}`);
-    // Aggiorno anche lo stato locale immediatamente così il caricamento non attende la navigazione
-    setFilters((prev) => ({ ...prev, onlyUnassigned: active }));
-    setCurrentPage(1);
-  }
-
   useEffect(() => {
     loadServices();
     setCurrentPage(1);
-  }, [filters.status, filters.driverId, filters.onlyUnassigned]);
+  }, [filters.status, filters.driverId, filters.fromDate, filters.toDate, filters.onlyUnassigned]);
 
   function resetForm() {
     setEditingId(null);
@@ -574,31 +607,16 @@ export function ServicesPanel() {
   }
 
   function openCreateForm() {
+    clearFeedbackNotice();
     resetForm();
     setIsFormOpen(true);
   }
 
   function closeForm() {
+    clearFeedbackNotice();
     resetForm();
     setIsFormOpen(false);
   }
-
-  useEffect(() => {
-    if (!isFormOpen) return;
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') closeForm();
-    }
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isFormOpen]);
-
-  useEffect(() => {
-    if (noticeServiceId !== null && selectedServiceId !== noticeServiceId) {
-      setError(null);
-      setSuccess(null);
-      setNoticeServiceId(null);
-    }
-  }, [selectedServiceId, noticeServiceId]);
 
   function toPayload(status: Exclude<ServiceStatus, 'CLOSED' | 'EXECUTED'>) {
     const assignmentType: ServiceAssignmentType = form.receivedFromPartner
@@ -760,7 +778,6 @@ export function ServicesPanel() {
     }
 
     setSuccess(editingId ? 'Servizio aggiornato' : 'Servizio creato');
-    setNoticeServiceId(serviceId);
     closeForm();
     await loadServices();
   }
@@ -815,7 +832,6 @@ export function ServicesPanel() {
     if (editingId === serviceId) {
       resetForm();
     }
-    setNoticeServiceId(null);
     setSuccess('Servizio eliminato');
     await loadServices();
   }
@@ -832,7 +848,6 @@ export function ServicesPanel() {
     }
 
     setSuccess('Servizio chiuso (pagamento registrato)');
-    setNoticeServiceId(serviceId);
     await loadServices();
   }
 
@@ -887,7 +902,6 @@ export function ServicesPanel() {
     }
 
     setSuccess('Servizio affidato a partner');
-    setNoticeServiceId(selectedService.id);
     closeOutsourceModal();
     await loadServices();
     await loadPartnerHistory(selectedService.id);
@@ -925,7 +939,6 @@ export function ServicesPanel() {
     }
 
     setSuccess('Email partner inserita in outbox');
-    setNoticeServiceId(serviceId);
     await loadPartnerHistory(serviceId);
   }
 
@@ -937,6 +950,7 @@ export function ServicesPanel() {
   }
 
   function togglePrintSelection(serviceId: number) {
+    clearFeedbackNotice();
     setSelectedForPrintIds((prev) => (
       prev.includes(serviceId)
         ? prev.filter((id) => id !== serviceId)
@@ -945,6 +959,7 @@ export function ServicesPanel() {
   }
 
   function toggleSelectAllOnPage(checked: boolean) {
+    clearFeedbackNotice();
     const pageIds = paginatedServices.map((item) => item.id);
     if (!checked) {
       setSelectedForPrintIds((prev) => prev.filter((id) => !pageIds.includes(id)));
@@ -991,8 +1006,7 @@ export function ServicesPanel() {
     if (!found) {
       return `#${service.assignedVehicleId}`;
     }
-    const description = found.notes?.trim() || found.type || null;
-    return description ? `${found.plate} - ${description}` : found.plate;
+    return found.plate;
   }
 
   function partnerLabel(partnerId: number | null) {
@@ -1006,25 +1020,34 @@ export function ServicesPanel() {
     return found.ragioneSociale;
   }
 
-  const orderedServices = useMemo(() => {
-    const q = filters.search.trim().toLowerCase();
-    const t = filters.type;
-    return [...services]
-      .filter((s) => {
-        if (t && s.type !== t) return false;
-        if (q) {
-          const haystack = [
-            s.internalBookingReference ?? '',
-            s.clientName ?? '',
-            s.pickupLocation,
-            s.destination
-          ].join(' ').toLowerCase();
-          if (!haystack.includes(q)) return false;
-        }
-        return true;
-      })
-      .sort((a, b) => new Date(b.startAt).getTime() - new Date(a.startAt).getTime());
-  }, [services, filters.search, filters.type]);
+  const orderedServices = useMemo(
+    () => {
+      const normalizedQuery = filters.query.trim().toLowerCase();
+
+      return [...services]
+        .filter((service) => {
+          if (filters.type && service.type !== filters.type) {
+            return false;
+          }
+
+          if (!normalizedQuery) {
+            return true;
+          }
+
+          const searchableValues = [
+            service.internalBookingReference ?? '',
+            service.externalBookingReference ?? '',
+            service.clientName ?? '',
+            service.pickupLocation,
+            service.destination
+          ];
+
+          return searchableValues.some((value) => value.toLowerCase().includes(normalizedQuery));
+        })
+        .sort((a, b) => new Date(b.startAt).getTime() - new Date(a.startAt).getTime());
+    },
+    [services, filters.query, filters.type]
+  );
 
   const overdueExecutedServices = useMemo(() => {
     const now = Date.now();
@@ -1041,7 +1064,7 @@ export function ServicesPanel() {
     });
   }, [orderedServices]);
 
-  const totalPages = Math.max(1, Math.ceil(orderedServices.length / pageSize));
+  const totalPages = Math.max(1, Math.ceil(orderedServices.length / PAGE_SIZE));
 
   useEffect(() => {
     if (currentPage > totalPages) {
@@ -1050,9 +1073,9 @@ export function ServicesPanel() {
   }, [currentPage, totalPages]);
 
   const paginatedServices = useMemo(() => {
-    const start = (currentPage - 1) * pageSize;
-    return orderedServices.slice(start, start + pageSize);
-  }, [orderedServices, currentPage, pageSize]);
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return orderedServices.slice(start, start + PAGE_SIZE);
+  }, [orderedServices, currentPage]);
 
   const selectedService = useMemo(
     () => orderedServices.find((item) => item.id === selectedServiceId) ?? null,
@@ -1086,7 +1109,7 @@ export function ServicesPanel() {
     }
     loadPartnerHistory(selectedServiceId);
     if (!orderedServices.some((item) => item.id === selectedServiceId)) {
-      setSelectedServiceId(null);
+      selectService(null);
     }
   }, [orderedServices, selectedServiceId]);
 
@@ -1095,165 +1118,320 @@ export function ServicesPanel() {
     setSelectedForPrintIds((prev) => prev.filter((id) => validIds.has(id)));
   }, [orderedServices]);
 
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filters.query, filters.type]);
 
   useEffect(() => {
-    setPortalTarget(document.getElementById('services-new-button-portal'));
+    function onDocumentClick(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (target && target.closest('.services-row-menu')) {
+        return;
+      }
+      setRowMenuServiceId(null);
+    }
+
+    function onDocumentKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setRowMenuServiceId(null);
+      }
+    }
+
+    document.addEventListener('click', onDocumentClick);
+    document.addEventListener('keydown', onDocumentKeyDown);
+    return () => {
+      document.removeEventListener('click', onDocumentClick);
+      document.removeEventListener('keydown', onDocumentKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    setNewButtonPortalTarget(document.getElementById('services-new-button-portal'));
   }, []);
 
   const allCurrentPageSelected = paginatedServices.length > 0
     && paginatedServices.every((service) => selectedForPrintIds.includes(service.id));
 
-  const newServiceBtn = (
+  const selectedDriverFilter = filters.driverId
+    ? drivers.find((driver) => driver.id === filters.driverId) ?? null
+    : null;
+
+  const activeFilterChips = [
+    filters.query.trim()
+      ? {
+          key: 'query',
+          icon: <SearchIcon />,
+          label: `Ricerca: ${filters.query.trim()}`,
+          onRemove: () => updateFilters((prev) => ({ ...prev, query: '' }))
+        }
+      : null,
+    filters.status
+      ? {
+          key: 'status',
+          icon: <FilterIcon />,
+          label: `Stato: ${statusLabel(filters.status)}`,
+          onRemove: () => updateFilters((prev) => ({ ...prev, status: '' }))
+        }
+      : null,
+    selectedDriverFilter
+      ? {
+          key: 'driver',
+          icon: <UserIcon />,
+          label: `Driver: ${driverLabel(selectedDriverFilter)}`,
+          onRemove: () => updateFilters((prev) => ({ ...prev, driverId: '' }))
+        }
+      : null,
+    filters.type
+      ? {
+          key: 'type',
+          icon: <FilterIcon />,
+          label: `Tipo: ${typeLabel(filters.type)}`,
+          onRemove: () => updateFilters((prev) => ({ ...prev, type: '' }))
+        }
+      : null,
+    filters.fromDate
+      ? {
+          key: 'fromDate',
+          icon: <CalendarIcon />,
+          label: `Dal: ${formatFilterDate(filters.fromDate)}`,
+          onRemove: () => updateFilters((prev) => ({ ...prev, fromDate: '' }))
+        }
+      : null,
+    filters.toDate
+      ? {
+          key: 'toDate',
+          icon: <CalendarIcon />,
+          label: `Al: ${formatFilterDate(filters.toDate)}`,
+          onRemove: () => updateFilters((prev) => ({ ...prev, toDate: '' }))
+        }
+      : null,
+    filters.onlyUnassigned
+      ? {
+          key: 'onlyUnassigned',
+          icon: <FilterIcon />,
+          label: 'Solo non assegnati',
+          onRemove: () => updateFilters((prev) => ({ ...prev, onlyUnassigned: false }))
+        }
+      : null
+  ].filter((chip): chip is NonNullable<typeof chip> => chip !== null);
+
+  const createServiceButton = (
     <button
       type="button"
       className="primary-button compact-button services-new-button"
-      onClick={openCreateForm}
+      onClick={() => {
+        if (isFormOpen && !editingId) {
+          closeForm();
+        } else {
+          openCreateForm();
+        }
+      }}
     >
-      <ButtonContent icon={<AddIcon />}>Nuovo servizio</ButtonContent>
+      <ButtonContent icon={isFormOpen && !editingId ? <LockIcon /> : <AddIcon />}>{isFormOpen && !editingId ? 'Chiudi form' : 'Nuovo servizio'}</ButtonContent>
     </button>
   );
 
+  function formatServiceDate(startAt: string) {
+    const date = new Date(startAt);
+    return {
+      date: date.toLocaleDateString('it-IT'),
+      time: date.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' })
+    };
+  }
+
+  function serviceInternalRef(service: ServiceItem) {
+    if (service.internalBookingReference && service.internalBookingReference.trim()) {
+      return service.internalBookingReference;
+    }
+    return `LUX-${service.id}`;
+  }
+
   return (
-    <>
-      {portalTarget && createPortal(newServiceBtn, portalTarget)}
-      <section className="responsive-panel services-panel" style={{ display: 'grid', gap: 16, maxWidth: '100%' }}>
+    <section className="responsive-panel services-panel" style={{ display: 'grid', gap: 16, maxWidth: '100%' }}>
+      <article className="dashboard-card services-filters-card">
+        <button
+          type="button"
+          className="services-filters-label"
+          onClick={() => setMobileFiltersOpen((prev) => !prev)}
+          aria-expanded={mobileFiltersOpen}
+          aria-controls="services-filters-grid"
+        >
+          <ButtonContent icon={mobileFiltersOpen ? <LockIcon /> : <FilterIcon />}>{mobileFiltersOpen ? 'Nascondi filtri' : 'Mostra filtri'}</ButtonContent>
+        </button>
+        <div
+          id="services-filters-grid"
+          className={`services-filters-panel services-filters-grid ${mobileFiltersOpen ? '' : 'is-hidden-mobile'}`}
+        >
+          <div className="services-filters-row">
+            <label className="services-search-wrap">
+              <span className="services-filter-label">Cerca</span>
+              <div className="services-search-input-wrap">
+                <span className="services-search-icon" aria-hidden="true"><SearchIcon /></span>
+                <input
+                  className="services-search-input"
+                  type="search"
+                  value={filters.query}
+                  onChange={(event) => updateFilters((prev) => ({ ...prev, query: event.target.value }))}
+                  placeholder="Rif, cliente, pickup, destinazione..."
+                />
+              </div>
+            </label>
 
-      {/* === Filtri card === */}
-      {(() => {
-        const hasActiveFilters = !!filters.status || !!filters.driverId || !!filters.type || !!filters.search || filters.onlyUnassigned;
-        const activeChips: { label: string; onRemove: () => void }[] = [];
-        if (filters.search) activeChips.push({ label: `Cerca: "${filters.search}"`, onRemove: () => setFilters((p) => ({ ...p, search: '' })) });
-        if (filters.status) activeChips.push({ label: `Stato: ${statusLabel(filters.status as ServiceStatus)}`, onRemove: () => setFilters((p) => ({ ...p, status: '' })) });
-        if (filters.driverId) {
-          const found = drivers.find((d) => d.id === filters.driverId);
-          activeChips.push({ label: `Driver: ${found ? driverLabel(found) : `#${filters.driverId}`}`, onRemove: () => setFilters((p) => ({ ...p, driverId: '' })) });
-        }
-        if (filters.type) activeChips.push({ label: `Tipo: ${typeLabel(filters.type as ServiceType)}`, onRemove: () => setFilters((p) => ({ ...p, type: '' })) });
-        if (filters.onlyUnassigned) activeChips.push({ label: 'Solo non assegnati', onRemove: () => setUnassignedFilter(false) });
+            <label className="services-filter-group services-filter-group--status">
+              <span className="services-filter-label">Stato</span>
+              <select
+                className="services-filter-select"
+                value={filters.status}
+                onChange={(event) => {
+                  const nextStatus = event.target.value as ServiceStatus | '';
+                  updateFilters((prev) => ({
+                    ...prev,
+                    status: nextStatus,
+                    onlyUnassigned: nextStatus === 'ASSIGNED' || nextStatus === 'EXECUTED' || nextStatus === 'CLOSED'
+                      ? false
+                      : prev.onlyUnassigned
+                  }));
+                }}
+              >
+                <option value="">Tutti</option>
+                <option value="OPEN">Aperti</option>
+                <option value="ASSIGNED">Assegnati</option>
+                <option value="EXECUTED">Eseguiti</option>
+                <option value="CLOSED">Chiusi</option>
+              </select>
+            </label>
 
-        return (
-          <article className="dashboard-card services-filters-card">
-            <div className="services-filters-row">
-              <div className="services-search-wrap">
-                <div className="services-search-input-wrap">
-                  <span className="services-search-icon"><SearchIcon /></span>
-                  <input
-                    className="services-search-input"
-                    placeholder="Rif, cliente, pickup, destinazione..."
-                    value={filters.search}
-                    onChange={(e) => { setFilters((p) => ({ ...p, search: e.target.value })); setCurrentPage(1); }}
-                  />
-                </div>
-              </div>
-              <div className="services-filter-group">
-                <span className="services-filter-label">Stato</span>
-                <select
-                  className="services-filter-select"
-                  value={filters.status}
-                  onChange={(event) => {
-                    const nextStatus = event.target.value as ServiceStatus | '';
-                    setFilters((prev) => ({
-                      ...prev,
-                      status: nextStatus,
-                      onlyUnassigned: nextStatus === 'ASSIGNED' || nextStatus === 'EXECUTED' || nextStatus === 'CLOSED'
-                        ? false
-                        : prev.onlyUnassigned
-                    }));
-                    setCurrentPage(1);
-                  }}
-                >
-                  <option value="">Tutti</option>
-                  <option value="OPEN">Aperti</option>
-                  <option value="ASSIGNED">Assegnati</option>
-                  <option value="EXECUTED">Eseguiti</option>
-                  <option value="CLOSED">Chiusi</option>
-                </select>
-              </div>
-              <div className="services-filter-group">
-                <span className="services-filter-label">Driver</span>
-                <select
-                  className="services-filter-select"
-                  value={filters.driverId}
-                  onChange={(event) => { setFilters((prev) => ({ ...prev, driverId: event.target.value ? Number(event.target.value) : '' })); setCurrentPage(1); }}
-                >
-                  <option value="">Tutti</option>
-                  {drivers.map((driver) => (
-                    <option key={driver.id} value={driver.id}>{driverLabel(driver)}</option>
-                  ))}
-                </select>
-              </div>
-              <div className="services-filter-group">
-                <span className="services-filter-label">Tipo</span>
-                <select
-                  className="services-filter-select"
-                  value={filters.type}
-                  onChange={(event) => { setFilters((prev) => ({ ...prev, type: event.target.value as ServiceType | '' })); setCurrentPage(1); }}
-                >
-                  <option value="">Tutti</option>
-                  <option value="TRANSFER">Transfer</option>
-                  <option value="TOUR">Tour</option>
-                </select>
+            <label className="services-filter-group services-filter-group--driver">
+              <span className="services-filter-label">Driver</span>
+              <select
+                className="services-filter-select"
+                value={filters.driverId}
+                onChange={(event) =>
+                  updateFilters((prev) => ({
+                    ...prev,
+                    driverId: event.target.value ? Number(event.target.value) : ''
+                  }))
+                }
+              >
+                <option value="">Tutti</option>
+                {drivers.map((driver) => (
+                  <option key={driver.id} value={driver.id}>{driverLabel(driver)}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="services-filter-group services-filter-group--type">
+              <span className="services-filter-label">Tipo</span>
+              <select
+                className="services-filter-select"
+                value={filters.type}
+                onChange={(event) => updateFilters((prev) => ({ ...prev, type: event.target.value as ServiceType | '' }))}
+              >
+                <option value="">Tutti</option>
+                <option value="TRANSFER">Transfer</option>
+                <option value="TOUR">Tour</option>
+              </select>
+            </label>
+
+            <button
+              type="button"
+              className={`services-filter-unassigned-btn ${filters.onlyUnassigned ? 'is-active' : ''}`}
+              onClick={() => updateFilters((prev) => ({ ...prev, onlyUnassigned: !prev.onlyUnassigned }))}
+              aria-pressed={filters.onlyUnassigned}
+            >
+              <span className="services-filter-unassigned-icon" aria-hidden="true"><FilterIcon /></span>
+              Solo non assegnati
+            </button>
+          </div>
+
+          <div className="services-filters-row services-filters-row-secondary">
+            <label className="services-filter-group">
+              <span className="services-filter-label">Da</span>
+              <input
+                className="services-filter-input"
+                type="date"
+                value={filters.fromDate}
+                onChange={(event) => updateFilters((prev) => ({ ...prev, fromDate: event.target.value }))}
+              />
+            </label>
+
+            <label className="services-filter-group">
+              <span className="services-filter-label">A</span>
+              <input
+                className="services-filter-input"
+                type="date"
+                value={filters.toDate}
+                onChange={(event) => updateFilters((prev) => ({ ...prev, toDate: event.target.value }))}
+              />
+            </label>
+          </div>
+
+          {activeFilterChips.length > 0 && (
+            <div className="services-active-filters-row">
+              <span className="services-active-filters-label">Filtri attivi:</span>
+              <div className="services-active-chips">
+                {activeFilterChips.map((chip) => (
+                  <span key={chip.key} className="services-active-chip">
+                    <span className="services-active-chip-icon" aria-hidden="true">{chip.icon}</span>
+                    {chip.label}
+                    <button
+                      type="button"
+                      className="services-active-chip-remove"
+                      onClick={chip.onRemove}
+                      aria-label={`Rimuovi filtro ${chip.label}`}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
               </div>
               <button
                 type="button"
-                className={`services-filter-unassigned-btn${filters.onlyUnassigned ? ' is-active' : ''}`}
-                onClick={() => setUnassignedFilter(!filters.onlyUnassigned)}
+                className="services-reset-link"
+                onClick={() => {
+                  clearFeedbackNotice();
+                  setFilters(defaultFilters);
+                }}
               >
-                <span className="services-filter-unassigned-icon"><FilterIcon /></span>
-                Solo non assegnati
+                Reset filtri
               </button>
             </div>
-            {hasActiveFilters && (
-              <div className="services-active-filters-row">
-                <span className="services-active-filters-label">Filtri attivi:</span>
-                <div className="services-active-chips">
-                  {activeChips.map((chip) => (
-                    <span key={chip.label} className="services-active-chip">
-                      {chip.label}
-                      <button type="button" className="services-active-chip-remove" onClick={chip.onRemove} aria-label={`Rimuovi filtro ${chip.label}`}>×</button>
-                    </span>
-                  ))}
-                </div>
-                <button type="button" className="services-reset-link" onClick={() => { setFilters(defaultFilters); setCurrentPage(1); }}>
-                  Reset filtri
-                </button>
-              </div>
-            )}
-          </article>
-        );
-      })()}
+          )}
+        </div>
+      </article>
 
       <article className="dashboard-card">
         <div className="panel-header services-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
           <h3 className="services-title">Lista servizi</h3>
         </div>
+        {newButtonPortalTarget ? createPortal(createServiceButton, newButtonPortalTarget) : null}
         {overdueExecutedServices.length > 0 && (
-          <div style={{ marginTop: 10, marginBottom: 10, padding: 10, borderRadius: 10, background: '#fff4df', border: '1px solid #f2d39a' }}>
-            <strong style={{ display: 'block', color: '#8a4b00' }}>
+          <div className="services-notice services-notice--warning" role="status" aria-live="polite" style={{ marginTop: 10, marginBottom: 10 }}>
+            <span className="services-notice-icon" aria-hidden="true"><ServiceNoticeIcon tone="warning" /></span>
+            <div className="services-notice-text">
+              <strong className="services-notice-title">
               Attenzione: {overdueExecutedServices.length} servizi in stato Eseguito da oltre 20 giorni
-            </strong>
-            <span style={{ color: '#8a4b00' }}>
-              Verifica l&apos;incasso dal partner e chiudi i servizi in sospeso.
-            </span>
+              </strong>
+              <span>Verifica l&apos;incasso dal partner e chiudi i servizi in sospeso.</span>
+            </div>
           </div>
         )}
         {error && (
-          <div className="services-notice services-notice--error">
-            <span className="services-notice-icon">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.8"/><line x1="12" y1="8" x2="12" y2="12.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/><circle cx="12" cy="15.5" r="0.9" fill="currentColor"/></svg>
-            </span>
-            <span className="services-notice-text"><strong>{error}</strong></span>
-            <button type="button" className="services-notice-close" aria-label="Chiudi" onClick={() => { setError(null); setNoticeServiceId(null); }}>×</button>
+          <div className="services-notice services-notice--error" role="alert" aria-live="assertive" style={{ marginBottom: 10 }}>
+            <span className="services-notice-icon" aria-hidden="true"><ServiceNoticeIcon tone="error" /></span>
+            <div className="services-notice-text">
+              <strong className="services-notice-title">Errore</strong>
+              <span>{error}</span>
+            </div>
           </div>
         )}
-        {success && (
-          <div className="services-notice services-notice--success">
-            <span className="services-notice-icon">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.8"/><polyline points="8 12.5 11 15.5 16 9.5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>
-            </span>
-            <span className="services-notice-text"><strong>{success}</strong></span>
-            <button type="button" className="services-notice-close" aria-label="Chiudi" onClick={() => { setSuccess(null); setNoticeServiceId(null); }}>×</button>
+        {!error && success && (
+          <div className="services-notice services-notice--info" role="status" aria-live="polite" style={{ marginBottom: 10 }}>
+            <span className="services-notice-icon" aria-hidden="true"><ServiceNoticeIcon tone="info" /></span>
+            <div className="services-notice-text">
+              <strong className="services-notice-title">Informazione</strong>
+              <span>{success}</span>
+            </div>
           </div>
         )}
         {loading ? (
@@ -1277,7 +1455,7 @@ export function ServicesPanel() {
                     type="button"
                     className="services-selected-close"
                     aria-label="Chiudi dettaglio servizio"
-                    onClick={() => setSelectedServiceId(null)}
+                    onClick={() => selectService(null)}
                   >
                     x
                   </button>
@@ -1428,103 +1606,154 @@ export function ServicesPanel() {
                   <button
                     type="button"
                     className="compact-button services-selected-deselect"
-                    onClick={() => setSelectedServiceId(null)}
+                    onClick={() => selectService(null)}
                   >
                     <span className="action-button-icon"><ActionDeselectIcon /></span>
                     Deseleziona
                   </button>
                 </div>
 
-                <div className="services-selected-divider" />
-                <div className="services-selected-history">
-                  <div className="services-selected-history-title">
-                    <span className="services-selected-history-heading">Storico partner servizio</span>
-                  </div>
-                  {partnerHistoryLoading ? (
-                    <p style={{ margin: 0, color: 'var(--muted)', fontSize: 14 }}>Caricamento storico...</p>
-                  ) : !partnerHistory ? (
-                    <p style={{ margin: 0, color: 'var(--muted)', fontSize: 14 }}>Nessuno storico disponibile per questo servizio.</p>
-                  ) : (
-                    <div style={{ display: 'grid', gap: 12 }}>
-                      <ServiceDetailRow
-                        icon={<DetailUserIcon />}
-                        label="Partner"
-                        value={`${partnerHistory.partnerRagioneSociale ?? '-'} (${partnerHistory.partnerEmail ?? '-'})`}
-                      />
-                      <ServiceDetailRow
-                        icon={<DetailMailIcon />}
-                        label="Comunicazioni inviate"
-                        value={partnerHistory.communications.length}
-                      />
-                      {partnerHistory.communications.length > 0 && (
-                        <div className="services-history-table-wrap">
-                          <table className="services-history-table">
-                            <thead>
-                              <tr>
-                                <th>Canale</th>
-                                <th>Destinatario</th>
-                                <th>Oggetto</th>
-                                <th>Data invio</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {partnerHistory.communications.map((communication) => (
-                                <tr key={communication.communicationId}>
-                                  <td>{communication.channel}</td>
-                                  <td>{communication.recipient}</td>
-                                  <td>{communication.subject}</td>
-                                  <td>{new Date(communication.createdAt).toLocaleString('it-IT')}</td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
-                        </div>
-                      )}
-                      <div>
-                        <button
-                          type="button"
-                          className="logout-button compact-button"
-                          onClick={() => sendPartnerEmailFromService(selectedService.id)}
-                          disabled={partnerEmailSending || !selectedService.partnerId}
-                        >
-                          <ButtonContent icon={<SharedPartnerIcon />}>{partnerEmailSending ? 'Invio email...' : 'Invia email al partner'}</ButtonContent>
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </div>
               </div>
             )}
-            <div className="services-list-topbar">
-              <span className="services-list-topbar-count">
-                {selectedForPrintIds.length} selezionati su {orderedServices.length} risultati
-              </span>
-              <div className="services-list-topbar-actions">
+
+            {selectedService && (
+              <article className="dashboard-card sph-card">
+                <div className="sph-header">
+                  <div className="sph-header-title">
+                    <span className="sph-header-icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                        <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.9" />
+                        <polyline points="12 7 12 12 15.5 14.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </span>
+                    <span className="sph-header-label">Storico partner servizio</span>
+                  </div>
+                  <span className="sph-comm-badge">
+                    # {partnerHistory?.communications.length ?? 0} comunicazion{(partnerHistory?.communications.length ?? 0) === 1 ? 'e' : 'i'}
+                  </span>
+                </div>
+
+                {partnerHistoryLoading ? (
+                  <p className="sph-empty">Caricamento storico...</p>
+                ) : !partnerHistory ? (
+                  <p className="sph-empty">Nessuno storico disponibile per questo servizio.</p>
+                ) : (
+                  <>
+                    <div className="sph-meta-row">
+                      <span className="sph-meta-item">
+                        <span className="sph-meta-icon" aria-hidden="true">
+                          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                            <circle cx="12" cy="8.3" r="3.2" fill="none" stroke="currentColor" strokeWidth="1.9" />
+                            <path d="M5.7 18.5c1.4-3.1 3.9-4.7 6.3-4.7s5 1.6 6.3 4.7" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+                          </svg>
+                        </span>
+                        <span className="sph-meta-key">PARTNER</span>
+                        <span className="sph-meta-val">{partnerHistory.partnerRagioneSociale ?? '-'}</span>
+                      </span>
+                      <span className="sph-meta-sep" aria-hidden="true" />
+                      <span className="sph-meta-item">
+                        <span className="sph-meta-icon" aria-hidden="true">
+                          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                            <rect x="2" y="5" width="20" height="14" rx="2" fill="none" stroke="currentColor" strokeWidth="1.9" />
+                            <polyline points="2 9 12 15 22 9" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinejoin="round" />
+                          </svg>
+                        </span>
+                        <span className="sph-meta-key">EMAIL</span>
+                        {partnerHistory.partnerEmail ? (
+                          <a className="sph-meta-link" href={`mailto:${partnerHistory.partnerEmail}`}>
+                            {partnerHistory.partnerEmail}
+                          </a>
+                        ) : (
+                          <span className="sph-meta-val">-</span>
+                        )}
+                      </span>
+                    </div>
+
+                    <div className="sph-divider" />
+
+                    {partnerHistory.communications.length === 0 ? (
+                      <p className="sph-empty">Nessuna comunicazione inviata.</p>
+                    ) : (
+                      <div className="table-scroll sph-table-wrap">
+                        <table className="sph-table">
+                          <thead>
+                            <tr>
+                              <th className="sph-th">Canale</th>
+                              <th className="sph-th">Destinatario</th>
+                              <th className="sph-th sph-th--subject">Oggetto</th>
+                              <th className="sph-th sph-th--date">Data invio</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {partnerHistory.communications.map((communication) => (
+                              <tr key={communication.communicationId} className="sph-tr">
+                                <td className="sph-td">
+                                  <span className="sph-channel-badge">{communication.channel.toUpperCase()}</span>
+                                </td>
+                                <td className="sph-td">{communication.recipient}</td>
+                                <td className="sph-td sph-td--subject">{communication.subject}</td>
+                                <td className="sph-td sph-td--date">{new Date(communication.createdAt).toLocaleString('it-IT')}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+
+                    <div className="sph-actions">
+                      <button
+                        type="button"
+                        className="sph-send-btn"
+                        onClick={() => sendPartnerEmailFromService(selectedService.id)}
+                        disabled={partnerEmailSending || !selectedService.partnerId}
+                      >
+                        <span className="sph-send-icon" aria-hidden="true">
+                          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                            <line x1="22" y1="2" x2="11" y2="13" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+                            <polygon points="22 2 15 22 11 13 2 9 22 2" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinejoin="round" />
+                          </svg>
+                        </span>
+                        {partnerEmailSending ? 'Invio in corso...' : 'Invia email al partner'}
+                      </button>
+                    </div>
+                  </>
+                )}
+              </article>
+            )}
+            <div className="services-selection-toolbar">
+              <div className="services-selection-summary">
+                <span className="services-selection-count">{selectedForPrintIds.length} selezionati</span>
+                <span className="services-selection-total">su {orderedServices.length} risultati</span>
+              </div>
+              <div className="services-selection-actions">
                 <button
                   type="button"
-                  className="services-list-topbar-btn"
+                  className="logout-button compact-button"
                   onClick={printSelectedServices}
-                >
-                  <span className="services-list-topbar-btn-icon"><SharedPrintIcon /></span>
-                  Stampa
-                </button>
-                <span className="services-list-topbar-sep" aria-hidden="true">|</span>
-                <button
-                  type="button"
-                  className="services-list-topbar-btn services-list-topbar-btn-clear"
-                  onClick={() => setSelectedForPrintIds([])}
                   disabled={selectedForPrintIds.length === 0}
                 >
-                  × Pulisci
+                  <ButtonContent icon={<SharedPrintIcon />}>Stampa</ButtonContent>
+                </button>
+                <button
+                  type="button"
+                  className="logout-button compact-button"
+                  onClick={() => {
+                    clearFeedbackNotice();
+                    setSelectedForPrintIds([]);
+                  }}
+                  disabled={selectedForPrintIds.length === 0}
+                >
+                  <ButtonContent icon={<CancelIcon />}>Pulisci</ButtonContent>
                 </button>
               </div>
             </div>
             <div className="table-scroll services-desktop-table" style={{ overflowX: 'auto', marginTop: 8, maxWidth: '100%' }}>
-            <table className="responsive-table services-table" style={{ width: '100%', minWidth: 900, borderCollapse: 'collapse' }}>
+            <table className="responsive-table services-table services-table-modern" style={{ width: '100%', minWidth: 1080, borderCollapse: 'collapse' }}>
               <thead>
                 <tr>
                   <th style={thStyle}>
                     <input
+                      className="services-table-checkbox"
                       type="checkbox"
                       checked={allCurrentPageSelected}
                       onChange={(event) => toggleSelectAllOnPage(event.target.checked)}
@@ -1538,108 +1767,108 @@ export function ServicesPanel() {
                   <th style={thStyle}>Driver / Veicolo</th>
                   <th style={thStyle}>Prezzo</th>
                   <th style={thStyle}>Stato</th>
-                  <th style={{ ...thStyle, width: 48 }} />
+                  <th style={thStyle} aria-label="Azioni" />
                 </tr>
               </thead>
               <tbody>
                 {paginatedServices.map((service) => {
-                  const d = new Date(service.startAt);
-                  const dateStr = d.toLocaleDateString('it-IT', { day: '2-digit', month: '2-digit', year: 'numeric' });
-                  const timeStr = d.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' });
-                  const isMenuOpen = openDropdownId === service.id;
+                  const serviceDate = formatServiceDate(service.startAt);
 
                   return (
-                    <tr
-                      key={service.id}
-                      style={{
-                        background: selectedServiceId === service.id ? '#eaf4ff' : 'transparent',
-                        color: service.status === 'CLOSED' ? '#7f8ea3' : 'inherit'
-                      }}
-                    >
-                      <td style={tdStyle}>
-                        <input
-                          type="checkbox"
-                          checked={selectedForPrintIds.includes(service.id)}
-                          onChange={() => togglePrintSelection(service.id)}
-                          aria-label={`Seleziona servizio ${service.id} per stampa multipla`}
-                        />
-                      </td>
-                      <td style={{ ...tdStyle, fontWeight: 600, whiteSpace: 'nowrap', fontSize: 13 }}>
-                        {service.internalBookingReference ?? <span style={{ color: '#b0b8c4', fontStyle: 'italic' }}>—</span>}
-                      </td>
-                      <td style={{ ...tdStyle, whiteSpace: 'nowrap' }}>
-                        <div style={{ fontWeight: 600, fontSize: 14 }}>{dateStr}</div>
-                        <div style={{ color: '#5f7693', fontSize: 13 }}>{timeStr}</div>
-                      </td>
-                      <td style={{ ...tdStyle, minWidth: 200, lineHeight: 1.4 }}>
-                        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
-                          <span className="services-tratta-icon services-tratta-icon-pin"><MobilePinIcon /></span>
-                          <span style={{ fontSize: 14 }}>{service.pickupLocation}</span>
+                  <tr
+                    key={service.id}
+                    className={`services-table-row ${selectedServiceId === service.id ? 'is-selected' : ''}`}
+                  >
+                    <td style={tdStyle}>
+                      <input
+                        className="services-table-checkbox"
+                        type="checkbox"
+                        checked={selectedForPrintIds.includes(service.id)}
+                        onChange={() => togglePrintSelection(service.id)}
+                        aria-label={`Seleziona servizio ${service.id} per stampa multipla`}
+                      />
+                    </td>
+                    <td style={tdStyle}>
+                      <span className="services-table-ref">{serviceInternalRef(service)}</span>
+                    </td>
+                    <td style={tdStyle}>
+                      <div className="services-table-datetime">
+                        <strong>{serviceDate.date}</strong>
+                        <span>{serviceDate.time}</span>
+                      </div>
+                    </td>
+                    <td style={tdStyle}>
+                      <div className="services-table-route">
+                        <div className="services-table-route-line">
+                          <span className="services-table-route-icon"><MobilePinIcon /></span>
+                          <span className="services-table-route-text">{service.pickupLocation}</span>
                         </div>
-                        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6, marginTop: 5 }}>
-                          <span className="services-tratta-icon services-tratta-icon-flag"><DestFlagIcon /></span>
-                          <span style={{ color: '#5f7693', fontSize: 14 }}>{service.destination}</span>
+                        <div className="services-table-route-line">
+                          <span className="services-table-route-icon"><CursorIcon /></span>
+                          <span className="services-table-route-text">{service.destination}</span>
                         </div>
-                      </td>
-                      <td style={tdStyle}>
-                        <span className="service-chip service-chip-type">{typeLabel(service.type)}</span>
-                      </td>
-                      <td style={{ ...tdStyle, minWidth: 140 }}>
-                        {service.assignedDriverId ? (
-                          <>
-                            <div style={{ fontWeight: 600, fontSize: 14 }}>{assignedDriverLabel(service)}</div>
-                            <div style={{ color: '#5f7693', fontSize: 13, display: 'flex', alignItems: 'center', gap: 4, marginTop: 2 }}>
-                              <span className="services-vehicle-icon"><DetailCarIcon /></span>
-                              {assignedVehicleLabel(service)}
-                            </div>
-                          </>
-                        ) : (
-                          <span style={{ color: '#b0b8c4', fontStyle: 'italic', fontSize: 14 }}>— Non assegnato</span>
-                        )}
-                      </td>
-                      <td style={{ ...tdStyle, fontWeight: 700, whiteSpace: 'nowrap', fontSize: 14 }}>
-                        {formatCurrencyEUR(service.price)}
-                      </td>
-                      <td style={tdStyle}>
-                        <span className={`service-chip service-chip-status ${statusClass(service.status)}`}>
-                          {statusLabel(service.status)}
+                      </div>
+                    </td>
+                    <td style={tdStyle}>
+                      <span className="service-chip service-chip-type-neutral">{typeLabel(service.type)}</span>
+                    </td>
+                    <td style={tdStyle}>
+                      <div className="services-table-driver-vehicle">
+                        <strong>{assignedDriverLabel(service)}</strong>
+                        <span>
+                          <span className="services-table-driver-vehicle-icon"><DetailCarIcon /></span>
+                          {assignedVehicleLabel(service)}
                         </span>
-                      </td>
-                      <td style={{ ...tdStyle, position: 'relative', width: 48 }}>
-                        <div className="services-row-menu">
-                          <button
-                            type="button"
-                            className="services-row-menu-btn"
-                            onClick={() => setOpenDropdownId(isMenuOpen ? null : service.id)}
-                            aria-label="Apri menu azioni"
-                            aria-expanded={isMenuOpen}
-                          >
-                            ···
-                          </button>
-                          {isMenuOpen && (
-                            <div className="services-row-menu-dropdown">
-                              <button
-                                type="button"
-                                className="services-row-menu-item"
-                                onClick={() => { setSelectedServiceId(service.id); setOpenDropdownId(null); }}
-                              >
-                                <span className="services-row-menu-item-icon"><EyeIcon /></span>
-                                Apri dettaglio
-                              </button>
-                              <button
-                                type="button"
-                                className="services-row-menu-item"
-                                onClick={() => { openPrint(service.id); setOpenDropdownId(null); }}
-                              >
-                                <span className="services-row-menu-item-icon"><ActionPrintIcon /></span>
-                                Stampa
-                              </button>
-                            </div>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  );
+                      </div>
+                    </td>
+                    <td style={tdStyle}>
+                      <strong className="services-table-price">{formatCurrencyEUR(service.price)}</strong>
+                    </td>
+                    <td style={tdStyle}>
+                      <span className={`service-chip service-chip-status-pill ${statusClass(service.status)}`}>
+                        {statusLabel(service.status)}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <div className="services-row-menu">
+                        <button
+                          type="button"
+                          className="services-row-menu-btn"
+                          aria-label={`Azioni servizio ${service.id}`}
+                          onClick={() => setRowMenuServiceId((prev) => prev === service.id ? null : service.id)}
+                        >
+                          •••
+                        </button>
+                        {rowMenuServiceId === service.id && (
+                          <div className="services-row-menu-dropdown">
+                            <button
+                              type="button"
+                              className="services-row-menu-item"
+                              onClick={() => {
+                                selectService(service.id);
+                                setRowMenuServiceId(null);
+                              }}
+                            >
+                              <span className="services-row-menu-item-icon"><ActionViewIcon /></span>
+                              Apri dettaglio
+                            </button>
+                            <button
+                              type="button"
+                              className="services-row-menu-item"
+                              onClick={() => {
+                                openPrint(service.id);
+                                setRowMenuServiceId(null);
+                              }}
+                            >
+                              <span className="services-row-menu-item-icon"><SharedPrintIcon /></span>
+                              Stampa
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
                 })}
               </tbody>
             </table>
@@ -1705,7 +1934,7 @@ export function ServicesPanel() {
                       <button
                         type="button"
                         className="primary-button compact-button"
-                        onClick={() => setSelectedServiceId(service.id)}
+                        onClick={() => selectService(service.id)}
                       >
                         <ButtonContent icon={<SelectIcon />}>Seleziona</ButtonContent>
                       </button>
@@ -1718,27 +1947,16 @@ export function ServicesPanel() {
                       </button>
                     </div>
                   </article>
-                );
+                  );
               })}
             </div>
             <div className="services-list-footer">
               <div className="services-list-footer-size">
-                Mostra
-                <select
-                  className="services-list-pagesize-select"
-                  value={pageSize}
-                  onChange={(event) => {
-                    setPageSize(Number(event.target.value));
-                    setCurrentPage(1);
-                  }}
-                  aria-label="Numero di risultati per pagina"
-                >
-                  <option value={10}>10</option>
+                <span>Mostra</span>
+                <select className="services-list-pagesize-select" value={PAGE_SIZE} disabled aria-label="Numero risultati per pagina">
                   <option value={25}>25</option>
-                  <option value={50}>50</option>
-                  <option value={100}>100</option>
                 </select>
-                di {orderedServices.length} risultati
+                <span>di {orderedServices.length} risultati</span>
               </div>
               <div className="services-list-footer-pagination">
                 <button
@@ -1748,7 +1966,7 @@ export function ServicesPanel() {
                   disabled={currentPage === 1}
                   aria-label="Pagina precedente"
                 >
-                  ‹ Prec
+                  <ButtonContent icon={<ArrowLeftIcon />}>Prec</ButtonContent>
                 </button>
                 <span className="services-list-page-info">Pagina {currentPage} di {totalPages}</span>
                 <button
@@ -1758,7 +1976,7 @@ export function ServicesPanel() {
                   disabled={currentPage === totalPages}
                   aria-label="Pagina successiva"
                 >
-                  Succ ›
+                  <ButtonContent icon={<ArrowRightIcon />}>Succ</ButtonContent>
                 </button>
               </div>
             </div>
@@ -1851,15 +2069,21 @@ export function ServicesPanel() {
         </div>
       )}
 
-      {isFormOpen && createPortal(
-        <div className="services-modal-backdrop" onClick={(e) => { if (e.target === e.currentTarget) closeForm(); }}>
-          <div className="services-modal" role="dialog" aria-modal="true" aria-label={editingId ? `Modifica servizio #${editingId}` : 'Nuovo servizio'}>
+      {isFormOpen && (
+        <div
+          className="services-modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-label={editingId ? `Modifica servizio ${editingId}` : 'Nuovo servizio'}
+          onClick={closeForm}
+        >
+          <article className="services-modal" onClick={(event) => event.stopPropagation()}>
             <div className="services-modal-header">
-              <h2 className="services-modal-title">{editingId ? `Modifica servizio #${editingId}` : 'Nuovo servizio'}</h2>
-              <button type="button" className="services-modal-close" aria-label="Chiudi" onClick={closeForm}>×</button>
+              <h3 className="services-modal-title">{editingId ? `Modifica servizio #${editingId}` : 'Nuovo servizio'}</h3>
+              <button type="button" className="services-modal-close" onClick={closeForm} aria-label="Chiudi modale servizio">×</button>
             </div>
             <div className="services-modal-body">
-          <form className="form-grid" onSubmit={onSubmit}>
+              <form className="form-grid" onSubmit={onSubmit}>
             <label>
               Data/ora inizio
               <input
@@ -1936,9 +2160,7 @@ export function ServicesPanel() {
               Rif. prenotazione esterno (opzionale)
               <input
                 className="form-input"
-                type="number"
-                min={0}
-                step="1"
+                type="text"
                 value={form.externalBookingReference}
                 onChange={(event) => setForm((prev) => ({ ...prev, externalBookingReference: event.target.value }))}
               />
@@ -2105,22 +2327,19 @@ export function ServicesPanel() {
               />
             </label>
 
-            <div className="form-actions sticky-mobile" style={{ display: 'flex', gap: 8 }}>
-              <button type="submit" className="primary-button compact-button" disabled={submitting}>
-                <ButtonContent icon={editingId ? <SaveIcon /> : <AddIcon />}>{submitting ? 'Salvataggio...' : editingId ? 'Aggiorna servizio' : 'Crea servizio'}</ButtonContent>
-              </button>
-              {editingId && (
-                <button type="button" className="logout-button" onClick={openCreateForm}><ButtonContent icon={<AddIcon />}>Nuovo servizio</ButtonContent></button>
-              )}
-              <button type="button" className="logout-button" onClick={closeForm}><ButtonContent icon={<LockIcon />}>Annulla</ButtonContent></button>
+                <div className="form-actions sticky-mobile" style={{ display: 'flex', gap: 8 }}>
+                  <button type="submit" className="primary-button compact-button" disabled={submitting}>
+                    <ButtonContent icon={editingId ? <SaveIcon /> : <AddIcon />}>{submitting ? 'Salvataggio...' : editingId ? 'Aggiorna servizio' : 'Crea servizio'}</ButtonContent>
+                  </button>
+                  {editingId && (
+                    <button type="button" className="logout-button" onClick={openCreateForm}><ButtonContent icon={<AddIcon />}>Nuovo servizio</ButtonContent></button>
+                  )}
+                </div>
+              </form>
             </div>
-          </form>
-            </div>
-          </div>
-        </div>,
-        document.body
+          </article>
+        </div>
       )}
     </section>
-    </>
   );
 }


### PR DESCRIPTION
## Modifiche incluse

### Frontend – services-panel.tsx
- Badge comunicazioni sempre visibile anche senza storico (con contatore 0)
- Email partner come link cliccabile (`<a href="mailto:">`)
- Canale comunicazione visualizzato in uppercase
- Responsive mobile per card storico partner (`@media max-width: 900px`)
- Pulsante creazione servizio con stato toggle apri/chiudi form
- Nuove icone: `ActionViewIcon`, `ServiceNoticeIcon` (error/warning/info variants)
- Refactoring filtri con query/fromDate/toDate
- Tabella moderna con CSS classes e gestione dropdown menu

### Frontend – globals.css
- Stili `sph-*` per card storico partner
- Stili notice migliorati (warning/info variants)
- Classe `.sph-meta-link` per email cliccabile
- Media query responsive per sph card
- Filtri servizi redesign, tabella moderna

### Frontend – admin-users-panel.tsx
- Label "Cliente" → "Tenant" nel filtro, colonna tabella e card mobile

### Backend – ListUserAdminAuditLogUseCase.java
- `findLatest(20, ...)` → `findLatest(10, ...)` per limitare il log

### Backend – ListUsersUseCase.java
- Dipendenza `TenantManagementRepositoryPort` → `TenantRepository`
- Chiamata `findAllByOrderByBusinessNameAsc()` → `findAll()`