### PR TITLE
feat(ui): nuove vesti grafiche — fleet, gestionale, partners, finance

### DIFF
--- a/frontend/app/(protected)/app/fleet/page.tsx
+++ b/frontend/app/(protected)/app/fleet/page.tsx
@@ -36,9 +36,6 @@ export default async function FleetPage({ searchParams }: FleetPageProps) {
 
   return (
     <main>
-      <h1>Gestione Flotta</h1>
-      <p>Gestione completa veicolo: anagrafica, scadenze/manutenzioni e piani ricorrenti.</p>
-      <FleetDeadlinesAlerts />
       <FleetVehicleManagement userRole={user?.role ?? 'UNKNOWN'} initialVehicleId={initialVehicleId} />
     </main>
   );

--- a/frontend/app/(protected)/app/partners/page.tsx
+++ b/frontend/app/(protected)/app/partners/page.tsx
@@ -27,8 +27,13 @@ export default async function PartnersPage() {
 
   return (
     <main>
-      <h1>Gestione Partner</h1>
-      <p>Anagrafica fornitori: agenzie turismo, operatori NCC e altre tipologie.</p>
+      <div className="services-page-header">
+        <div className="services-page-header-text">
+          <h1>Gestione Partner</h1>
+          <p className="services-page-subtitle">Anagrafica fornitori: agenzie turismo, operatori NCC e altre tipologie.</p>
+        </div>
+        <div id="partners-new-button-portal" />
+      </div>
       <PartnersManagement userRole={user?.role ?? 'UNKNOWN'} />
     </main>
   );

--- a/frontend/app/(protected)/app/partners/partners-management.tsx
+++ b/frontend/app/(protected)/app/partners/partners-management.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
-import { AddIcon, ButtonContent, CancelIcon, CursorIcon, DeleteIcon, EditIcon, FilterIcon, LockIcon, ResetIcon, SaveIcon, SelectIcon } from '../../../../components/action-icons';
+import { createPortal } from 'react-dom';
+import { AddIcon, ButtonContent, CursorIcon, DeleteIcon, EditIcon, LockIcon, ResetIcon, SaveIcon, SearchIcon, SelectIcon } from '../../../../components/action-icons';
+import { StatusNotice } from '../../../../components/status-notice';
 
 type PartnerType = 'AGENZIA' | 'NCC' | 'ALTRO';
 
@@ -161,14 +163,13 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
   const [selectedPartnerId, setSelectedPartnerId] = useState<number | ''>('');
   const [selectedPartnerDetail, setSelectedPartnerDetail] = useState<PartnerItem | null>(null);
 
-  const [showFiltersCard, setShowFiltersCard] = useState(false);
-  const [filterRagioneSociale, setFilterRagioneSociale] = useState('');
-  const [filterType, setFilterType] = useState<'ALL' | PartnerType>('ALL');
+  const [partnerQuery, setPartnerQuery] = useState('');
   const [showDeleted, setShowDeleted] = useState(false);
 
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [isEditMode, setIsEditMode] = useState(false);
+  const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+  const [editingPartnerId, setEditingPartnerId] = useState<number | null>(null);
   const [form, setForm] = useState<PartnerFormState>(defaultForm);
+  const [newButtonPortalTarget, setNewButtonPortalTarget] = useState<HTMLElement | null>(null);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -179,12 +180,6 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
     setError(null);
 
     const query = new URLSearchParams();
-    if (filterRagioneSociale.trim()) {
-      query.set('ragioneSociale', filterRagioneSociale.trim());
-    }
-    if (filterType !== 'ALL') {
-      query.set('type', filterType);
-    }
     if (showDeleted) {
       query.set('includeDeleted', 'true');
     }
@@ -202,7 +197,7 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
 
     setPartners(payload as PartnerItem[]);
     setLoading(false);
-  }, [filterRagioneSociale, filterType, showDeleted]);
+  }, [showDeleted]);
 
   async function loadPartnerDetail(partnerId: number) {
     const response = await fetch(`/api/partners/${partnerId}`, { cache: 'no-store' });
@@ -249,12 +244,15 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
   useEffect(() => {
     if (!selectedPartnerId) {
       setSelectedPartnerDetail(null);
-      setIsEditMode(false);
       return;
     }
 
     loadPartnerDetail(selectedPartnerId);
   }, [selectedPartnerId]);
+
+  useEffect(() => {
+    setNewButtonPortalTarget(document.getElementById('partners-new-button-portal'));
+  }, []);
 
   const visiblePartners = useMemo(() => {
     // Safety fallback: if API ignores includeDeleted, still hide deleted by default.
@@ -263,6 +261,26 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
     }
     return partners;
   }, [partners, showDeleted]);
+
+  const filteredPartners = useMemo(() => {
+    const query = partnerQuery.trim().toLowerCase();
+    if (!query) {
+      return visiblePartners;
+    }
+
+    return visiblePartners.filter((partner) => {
+      const searchableParts = [
+        partner.ragioneSociale,
+        partner.nomeReferente ?? '',
+        partner.cognomeReferente ?? '',
+        partner.telefono ?? '',
+        partner.email ?? '',
+        typeLabel(partner.type)
+      ];
+
+      return searchableParts.join(' ').toLowerCase().includes(query);
+    });
+  }, [partnerQuery, visiblePartners]);
 
   function toPayload(current: PartnerFormState) {
     return {
@@ -306,7 +324,8 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
 
     const created = payload as PartnerItem;
     setSuccess('Partner creato');
-    setShowCreateForm(false);
+    setIsFormModalOpen(false);
+    setEditingPartnerId(null);
     setForm(defaultForm);
     setSelectedPartnerId(created.id);
     await loadPartners();
@@ -334,7 +353,8 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
     }
 
     setSuccess('Partner aggiornato');
-    setIsEditMode(false);
+    setIsFormModalOpen(false);
+    setEditingPartnerId(null);
     await loadPartners();
     await loadPartnerDetail(selectedPartnerId);
   }
@@ -360,19 +380,39 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
     setSuccess('Partner cancellato logicamente');
     setSelectedPartnerId('');
     setSelectedPartnerDetail(null);
-    setIsEditMode(false);
     await loadPartners();
   }
 
   function selectPartner(partnerId: number) {
     setSelectedPartnerId(partnerId);
-    setIsEditMode(false);
   }
 
   function deselectPartner() {
     setSelectedPartnerId('');
     setSelectedPartnerDetail(null);
-    setIsEditMode(false);
+  }
+
+  function openCreateModal() {
+    setError(null);
+    setSuccess(null);
+    setEditingPartnerId(null);
+    setForm(defaultForm);
+    setIsFormModalOpen(true);
+  }
+
+  async function openEditModal(partnerId: number) {
+    setError(null);
+    setSuccess(null);
+    setEditingPartnerId(partnerId);
+    setSelectedPartnerId(partnerId);
+    await loadPartnerDetail(partnerId);
+    setIsFormModalOpen(true);
+  }
+
+  function closeFormModal() {
+    setIsFormModalOpen(false);
+    setEditingPartnerId(null);
+    setForm(defaultForm);
   }
 
   if (!isAllowed) {
@@ -383,113 +423,43 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
     );
   }
 
+  const createPartnerButton = (
+    <button
+      type="button"
+      className="primary-button compact-button"
+      onClick={() => {
+        if (isFormModalOpen && editingPartnerId === null) {
+          closeFormModal();
+        } else {
+          openCreateModal();
+        }
+        setSelectedPartnerId('');
+      }}
+    >
+      <ButtonContent icon={isFormModalOpen && editingPartnerId === null ? <LockIcon /> : <AddIcon />}>
+        {isFormModalOpen && editingPartnerId === null ? 'Chiudi nuovo partner' : 'Nuovo partner'}
+      </ButtonContent>
+    </button>
+  );
+
   return (
     <section className="responsive-panel partners-management-panel" style={{ display: 'grid', gap: 16 }}>
-      {showCreateForm && (
-        <article className="dashboard-card">
-          <div className="panel-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-            <h3>Nuovo Partner</h3>
-            <button
-              type="button"
-              className="primary-button compact-button"
-              onClick={() => {
-                setShowCreateForm(false);
-                setForm(defaultForm);
-              }}
-            >
-              <ButtonContent icon={<LockIcon />}>Chiudi</ButtonContent>
-            </button>
-          </div>
-
-          <form className="form-grid" onSubmit={createPartner}>
-            <label>
-              Tipologia
-              <select className="form-input" value={form.type} onChange={(e) => setForm((p) => ({ ...p, type: e.target.value as PartnerType }))}>
-                <option value="AGENZIA">Agenzia</option>
-                <option value="NCC">NCC</option>
-                <option value="ALTRO">Altro</option>
-              </select>
-            </label>
-            <label>
-              Ragione Sociale
-              <input className="form-input" value={form.ragioneSociale} onChange={(e) => setForm((p) => ({ ...p, ragioneSociale: e.target.value }))} required />
-            </label>
-            <label>
-              Nome Referente
-              <input className="form-input" value={form.nomeReferente} onChange={(e) => setForm((p) => ({ ...p, nomeReferente: e.target.value }))} />
-            </label>
-            <label>
-              Cognome Referente
-              <input className="form-input" value={form.cognomeReferente} onChange={(e) => setForm((p) => ({ ...p, cognomeReferente: e.target.value }))} />
-            </label>
-            <label>
-              Telefono
-              <input className="form-input" value={form.telefono} onChange={(e) => setForm((p) => ({ ...p, telefono: e.target.value }))} />
-            </label>
-            <label>
-              Email
-              <input className="form-input" type="email" value={form.email} onChange={(e) => setForm((p) => ({ ...p, email: e.target.value }))} />
-            </label>
-            <label>
-              Citta`
-              <input className="form-input" value={form.citta} onChange={(e) => setForm((p) => ({ ...p, citta: e.target.value }))} />
-            </label>
-            <label>
-              Indirizzo
-              <input className="form-input" value={form.indirizzo} onChange={(e) => setForm((p) => ({ ...p, indirizzo: e.target.value }))} />
-            </label>
-            <label>
-              Zona Operativa
-                <input className="form-input" value={form.zonaOperativa} onChange={(e) => setForm((p) => ({ ...p, zonaOperativa: e.target.value }))} />
-            </label>
-            <label>
-              Partita IVA
-              <input className="form-input" value={form.partitaIva} onChange={(e) => setForm((p) => ({ ...p, partitaIva: e.target.value }))} />
-            </label>
-            <label>
-              Codice Fiscale
-              <input className="form-input" value={form.codiceFiscale} onChange={(e) => setForm((p) => ({ ...p, codiceFiscale: e.target.value }))} />
-            </label>
-            <label>
-              IBAN
-              <input className="form-input" value={form.iban} onChange={(e) => setForm((p) => ({ ...p, iban: e.target.value }))} />
-            </label>
-            <label>
-              Intestatario Conto
-              <input className="form-input" value={form.intestatarioConto} onChange={(e) => setForm((p) => ({ ...p, intestatarioConto: e.target.value }))} />
-            </label>
-            <label>
-              Note Pagamenti
-              <input className="form-input" value={form.notePagamenti} onChange={(e) => setForm((p) => ({ ...p, notePagamenti: e.target.value }))} />
-            </label>
-            <label>
-              Telefono WhatsApp
-              <input className="form-input" value={form.telefonoWhatsApp} onChange={(e) => setForm((p) => ({ ...p, telefonoWhatsApp: e.target.value }))} />
-            </label>
-            <label>
-              Note Operative
-              <input className="form-input" value={form.noteOperative} onChange={(e) => setForm((p) => ({ ...p, noteOperative: e.target.value }))} />
-            </label>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input type="checkbox" checked={form.riceveEmail} onChange={(e) => setForm((p) => ({ ...p, riceveEmail: e.target.checked }))} />
-              Riceve Email
-            </label>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input type="checkbox" checked={form.riceveWhatsApp} onChange={(e) => setForm((p) => ({ ...p, riceveWhatsApp: e.target.checked }))} />
-              Riceve WhatsApp
-            </label>
-            <div className="form-actions" style={{ display: 'flex', gap: 8 }}>
-              <button type="submit" className="primary-button compact-button"><ButtonContent icon={<AddIcon />}>Crea partner</ButtonContent></button>
-              <button type="button" className="logout-button compact-button" onClick={() => setForm(defaultForm)}><ButtonContent icon={<ResetIcon />}>Reset</ButtonContent></button>
-            </div>
-          </form>
-        </article>
-      )}
+      {newButtonPortalTarget ? createPortal(createPartnerButton, newButtonPortalTarget) : null}
 
       <article className="dashboard-card gestionale-partner-list-card">
         <div className="panel-header gestionale-partner-toolbar">
           <h3>Partner</h3>
           <div className="panel-actions gestionale-partner-toolbar-actions">
+            <label className="gestionale-partner-search" aria-label="Ricerca partner">
+              <span className="gestionale-partner-search-icon" aria-hidden="true"><SearchIcon /></span>
+              <input
+                type="search"
+                className="gestionale-partner-search-input"
+                value={partnerQuery}
+                onChange={(event) => setPartnerQuery(event.target.value)}
+                placeholder="Cerca per ragione sociale, referente, telefono o email"
+              />
+            </label>
             <label className="gestionale-partner-include-toggle">
               <input
                 type="checkbox"
@@ -498,13 +468,6 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
               />
               Includi cancellati
             </label>
-            <button
-              type="button"
-              className="primary-button compact-button"
-              onClick={() => setShowCreateForm(true)}
-            >
-              <ButtonContent icon={<AddIcon />}>Nuovo partner</ButtonContent>
-            </button>
           </div>
         </div>
 
@@ -519,7 +482,7 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
               </tr>
             </thead>
             <tbody>
-              {visiblePartners.map((partner) => {
+              {filteredPartners.map((partner) => {
                 const isSelected = selectedPartnerId === partner.id;
                 return (
                   <tr
@@ -537,10 +500,7 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
                         <button
                           type="button"
                           className="primary-button compact-button"
-                          onClick={() => {
-                            selectPartner(partner.id);
-                            setIsEditMode(true);
-                          }}
+                          onClick={() => openEditModal(partner.id)}
                           disabled={partner.deleted}
                         >
                           <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
@@ -553,21 +513,25 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
             </tbody>
           </table>
           {loading && <p className="gestionale-partner-table-empty">Caricamento partner...</p>}
-          {!loading && visiblePartners.length === 0 && <p className="gestionale-partner-table-empty">Nessun partner trovato.</p>}
+          {!loading && filteredPartners.length === 0 && <p className="gestionale-partner-table-empty">Nessun partner trovato.</p>}
         </div>
 
         <div className="gestionale-partner-mobile-list-wrap">
-          <h4 className="gestionale-partner-mobile-list-title">Partner ({visiblePartners.length})</h4>
-
           <div className="gestionale-partner-mobile-list">
-            {visiblePartners.map((partner) => {
+            {filteredPartners.map((partner) => {
               const isSelected = selectedPartnerId === partner.id;
               return (
                 <button
                   key={`mobile-${partner.id}`}
                   type="button"
                   className={`gestionale-partner-mobile-item ${isSelected ? 'is-selected' : ''}`}
-                  onClick={() => selectPartner(partner.id)}
+                  onClick={() => {
+                    if (isSelected) {
+                      deselectPartner();
+                    } else {
+                      selectPartner(partner.id);
+                    }
+                  }}
                 >
                   <span className="gestionale-partner-mobile-icon" aria-hidden="true">{typeLabel(partner.type).charAt(0)}</span>
 
@@ -583,7 +547,7 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
           </div>
 
           {loading && <p className="gestionale-partner-table-empty">Caricamento partner...</p>}
-          {!loading && visiblePartners.length === 0 && <p className="gestionale-partner-table-empty">Nessun partner trovato.</p>}
+          {!loading && filteredPartners.length === 0 && <p className="gestionale-partner-table-empty">Nessun partner trovato.</p>}
         </div>
       </article>
 
@@ -601,10 +565,10 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
               <button
                 type="button"
                 className="primary-button compact-button"
-                onClick={() => setIsEditMode((prev) => !prev)}
+                onClick={() => selectedPartnerId && openEditModal(selectedPartnerId)}
                 disabled={selectedPartnerDetail.deleted}
               >
-                <ButtonContent icon={isEditMode ? <LockIcon /> : <EditIcon />}>{isEditMode ? 'Chiudi modifica' : 'Modifica'}</ButtonContent>
+                <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
               </button>
               <button
                 type="button"
@@ -700,8 +664,35 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
             </div>
           </section>
 
-          {isEditMode && (
-            <form className="form-grid" onSubmit={updatePartner} style={{ marginTop: 10 }}>
+        </article>
+      )}
+
+      {isFormModalOpen && (
+        <div
+          className="tenant-modal-overlay"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) {
+              closeFormModal();
+            }
+          }}
+        >
+          <article className="tenant-modal-card" onClick={(event) => event.stopPropagation()}>
+            <div className="tenant-modal-header">
+              <div>
+                <h3>{editingPartnerId ? 'Modifica partner' : 'Nuovo partner'}</h3>
+                <p>{editingPartnerId ? 'Aggiorna i dati anagrafici e operativi del partner.' : 'Inserisci un nuovo partner in anagrafica.'}</p>
+              </div>
+              <button
+                type="button"
+                className="tenant-modal-close"
+                aria-label="Chiudi modale partner"
+                onClick={closeFormModal}
+              >
+                ×
+              </button>
+            </div>
+
+            <form className="form-grid" onSubmit={editingPartnerId ? updatePartner : createPartner}>
               <label>
                 Tipologia
                 <select className="form-input" value={form.type} onChange={(e) => setForm((p) => ({ ...p, type: e.target.value as PartnerType }))}>
@@ -779,18 +770,22 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
                 Riceve WhatsApp
               </label>
               <div className="form-actions" style={{ display: 'flex', gap: 8 }}>
-                <button type="submit" className="primary-button compact-button"><ButtonContent icon={<SaveIcon />}>Salva modifiche</ButtonContent></button>
-                <button type="button" className="logout-button compact-button" onClick={() => selectedPartnerId && loadPartnerDetail(selectedPartnerId)}>
+                <button type="submit" className="primary-button compact-button">
+                  <ButtonContent icon={editingPartnerId ? <SaveIcon /> : <AddIcon />}>
+                    {editingPartnerId ? 'Salva modifiche' : 'Crea partner'}
+                  </ButtonContent>
+                </button>
+                <button type="button" className="logout-button compact-button" onClick={() => setForm(defaultForm)}>
                   <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
                 </button>
               </div>
             </form>
-          )}
-        </article>
+          </article>
+        </div>
       )}
 
-      {error && <p className="error-text">{error}</p>}
-      {success && <p style={{ color: '#2e7d32' }}>{success}</p>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
+      {success && <StatusNotice tone="success">{success}</StatusNotice>}
     </section>
   );
 }

--- a/frontend/app/(protected)/app/partners/partners-management.tsx
+++ b/frontend/app/(protected)/app/partners/partners-management.tsx
@@ -100,6 +100,11 @@ function valueOrDash(value: string | null | undefined) {
   return value;
 }
 
+function referenteLabel(partner: PartnerItem) {
+  const fullName = `${partner.nomeReferente ?? ''} ${partner.cognomeReferente ?? ''}`.trim();
+  return fullName || '—';
+}
+
 function currencyEur(value: number | null | undefined) {
   const amount = value ?? 0;
   return `€ ${amount.toFixed(2)}`;
@@ -168,6 +173,8 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
 
   const [isFormModalOpen, setIsFormModalOpen] = useState(false);
   const [editingPartnerId, setEditingPartnerId] = useState<number | null>(null);
+  const [rowMenuPartnerId, setRowMenuPartnerId] = useState<number | null>(null);
+  const [rowMenuAnchor, setRowMenuAnchor] = useState<{ top: number; right: number } | null>(null);
   const [form, setForm] = useState<PartnerFormState>(defaultForm);
   const [newButtonPortalTarget, setNewButtonPortalTarget] = useState<HTMLElement | null>(null);
 
@@ -254,6 +261,29 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
     setNewButtonPortalTarget(document.getElementById('partners-new-button-portal'));
   }, []);
 
+  useEffect(() => {
+    function onDocumentClick(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (target && target.closest('.services-row-menu')) {
+        return;
+      }
+      setRowMenuPartnerId(null);
+    }
+
+    function onDocumentKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setRowMenuPartnerId(null);
+      }
+    }
+
+    document.addEventListener('click', onDocumentClick);
+    document.addEventListener('keydown', onDocumentKeyDown);
+
+    return () => {
+      document.removeEventListener('click', onDocumentClick);
+      document.removeEventListener('keydown', onDocumentKeyDown);
+    };
+  }, []);
   const visiblePartners = useMemo(() => {
     // Safety fallback: if API ignores includeDeleted, still hide deleted by default.
     if (!showDeleted) {
@@ -286,6 +316,7 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
     return {
       type: current.type,
       ragioneSociale: current.ragioneSociale,
+
       nomeReferente: current.nomeReferente || null,
       cognomeReferente: current.cognomeReferente || null,
       telefono: current.telefono || null,
@@ -476,6 +507,7 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
             <thead>
               <tr>
                 <th>Ragione Sociale</th>
+                <th>Referente</th>
                 <th>Telefono</th>
                 <th>Email</th>
                 <th>Azioni</th>
@@ -490,21 +522,56 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
                     className={`gestionale-partner-row ${isSelected ? 'is-selected' : ''} ${partner.deleted ? 'is-deleted' : ''}`}
                   >
                     <td>{partner.ragioneSociale}</td>
+                    <td>{referenteLabel(partner)}</td>
                     <td>{partner.telefono ?? '-'}</td>
                     <td>{partner.email ?? '-'}</td>
                     <td>
-                      <div className="table-actions gestionale-partner-table-actions">
-                        <button type="button" className="primary-button compact-button" onClick={() => selectPartner(partner.id)}>
-                          <ButtonContent icon={<SelectIcon />}>Seleziona</ButtonContent>
-                        </button>
+                      <div className="services-row-menu">
                         <button
                           type="button"
-                          className="primary-button compact-button"
-                          onClick={() => openEditModal(partner.id)}
-                          disabled={partner.deleted}
+                          className="services-row-menu-btn"
+                          aria-label={`Azioni partner ${partner.id}`}
+                          title="Azioni"
+                          onClick={(e) => {
+                            const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                            setRowMenuAnchor({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+                            setRowMenuPartnerId((prev) => (prev === partner.id ? null : partner.id));
+                          }}
                         >
-                          <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
+                          ...
                         </button>
+
+                        {rowMenuPartnerId === partner.id && rowMenuAnchor && (
+                          <div
+                            className="services-row-menu-dropdown"
+                            style={{ position: 'fixed', top: `${rowMenuAnchor.top}px`, right: `${rowMenuAnchor.right}px`, zIndex: 9999 }}
+                          >
+                            <button
+                              type="button"
+                              className="services-row-menu-item"
+                              onClick={() => {
+                                setRowMenuPartnerId(null);
+                                selectPartner(partner.id);
+                              }}
+                            >
+                              <span className="services-row-menu-item-icon"><SelectIcon /></span>
+                              Seleziona
+                            </button>
+
+                            <button
+                              type="button"
+                              className="services-row-menu-item"
+                              onClick={() => {
+                                setRowMenuPartnerId(null);
+                                void openEditModal(partner.id);
+                              }}
+                              disabled={partner.deleted}
+                            >
+                              <span className="services-row-menu-item-icon"><EditIcon /></span>
+                              Modifica
+                            </button>
+                          </div>
+                        )}
                       </div>
                     </td>
                   </tr>

--- a/frontend/app/(protected)/app/partners/partners-management.tsx
+++ b/frontend/app/(protected)/app/partners/partners-management.tsx
@@ -385,25 +385,22 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
 
   return (
     <section className="responsive-panel partners-management-panel" style={{ display: 'grid', gap: 16 }}>
-      <article className="dashboard-card">
-        <div className="panel-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-          <h2>Gestione Partner</h2>
-          <button
-            type="button"
-            className="primary-button compact-button"
-            onClick={() => {
-              setShowCreateForm((prev) => !prev);
-              setIsEditMode(false);
-              setSelectedPartnerId('');
-              setForm(defaultForm);
-            }}
-          >
-            <ButtonContent icon={showCreateForm ? <LockIcon /> : <AddIcon />}>{showCreateForm ? 'Chiudi nuovo partner' : 'Nuovo partner'}</ButtonContent>
-          </button>
-        </div>
-        <p>Gestisci anagrafica e operativita` di agenzie, NCC e altri fornitori.</p>
+      {showCreateForm && (
+        <article className="dashboard-card">
+          <div className="panel-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+            <h3>Nuovo Partner</h3>
+            <button
+              type="button"
+              className="primary-button compact-button"
+              onClick={() => {
+                setShowCreateForm(false);
+                setForm(defaultForm);
+              }}
+            >
+              <ButtonContent icon={<LockIcon />}>Chiudi</ButtonContent>
+            </button>
+          </div>
 
-        {showCreateForm && (
           <form className="form-grid" onSubmit={createPartner}>
             <label>
               Tipologia
@@ -443,7 +440,7 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
             </label>
             <label>
               Zona Operativa
-              <input className="form-input" value={form.zonaOperativa} onChange={(e) => setForm((p) => ({ ...p, zonaOperativa: e.target.value }))} />
+                <input className="form-input" value={form.zonaOperativa} onChange={(e) => setForm((p) => ({ ...p, zonaOperativa: e.target.value }))} />
             </label>
             <label>
               Partita IVA
@@ -486,108 +483,108 @@ export function PartnersManagement({ userRole = 'UNKNOWN' }: PartnersManagementP
               <button type="button" className="logout-button compact-button" onClick={() => setForm(defaultForm)}><ButtonContent icon={<ResetIcon />}>Reset</ButtonContent></button>
             </div>
           </form>
-        )}
-      </article>
+        </article>
+      )}
 
-      <article className="dashboard-card">
-        <div className="panel-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-          <h3>Filtri</h3>
-          <button type="button" className="logout-button compact-button" onClick={() => setShowFiltersCard((prev) => !prev)}>
-            <ButtonContent icon={showFiltersCard ? <LockIcon /> : <FilterIcon />}>{showFiltersCard ? 'Chiudi filtri' : 'Apri filtri'}</ButtonContent>
-          </button>
+      <article className="dashboard-card gestionale-partner-list-card">
+        <div className="panel-header gestionale-partner-toolbar">
+          <h3>Partner</h3>
+          <div className="panel-actions gestionale-partner-toolbar-actions">
+            <label className="gestionale-partner-include-toggle">
+              <input
+                type="checkbox"
+                checked={showDeleted}
+                onChange={(e) => setShowDeleted(e.target.checked)}
+              />
+              Includi cancellati
+            </label>
+            <button
+              type="button"
+              className="primary-button compact-button"
+              onClick={() => setShowCreateForm(true)}
+            >
+              <ButtonContent icon={<AddIcon />}>Nuovo partner</ButtonContent>
+            </button>
+          </div>
         </div>
 
-        {showFiltersCard && (
-          <div className="form-grid" style={{ display: 'grid', gap: 10, marginTop: 8 }}>
-            <label>
-              Ragione Sociale
-              <input className="form-input" value={filterRagioneSociale} onChange={(e) => setFilterRagioneSociale(e.target.value)} />
-            </label>
-            <label>
-              Tipologia
-              <select className="form-input" value={filterType} onChange={(e) => setFilterType(e.target.value as 'ALL' | PartnerType)}>
-                <option value="ALL">Tutte</option>
-                <option value="AGENZIA">Agenzia</option>
-                <option value="NCC">NCC</option>
-                <option value="ALTRO">Altro</option>
-              </select>
-            </label>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input type="checkbox" checked={showDeleted} onChange={(e) => setShowDeleted(e.target.checked)} />
-              Mostra partner cancellati
-            </label>
-            <div className="form-actions" style={{ display: 'flex', gap: 8 }}>
-              <button
-                type="button"
-                className="logout-button compact-button"
-                onClick={() => {
-                  setFilterRagioneSociale('');
-                  setFilterType('ALL');
-                  setShowDeleted(false);
-                }}
-              >
-                <ButtonContent icon={<ResetIcon />}>Reset filtri</ButtonContent>
-              </button>
-            </div>
-          </div>
-        )}
-      </article>
-
-      <article className="dashboard-card">
-        <h3>Lista Partner</h3>
-        {loading ? (
-          <p>Caricamento partner...</p>
-        ) : (
-          <div className="table-scroll" style={{ overflowX: 'auto', marginTop: 8 }}>
-            <table className="responsive-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr>
-                  <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Ragione Sociale</th>
-                  <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Telefono</th>
-                  <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Email</th>
-                  <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Azioni</th>
-                </tr>
-              </thead>
-              <tbody>
-                {visiblePartners.length === 0 ? (
-                  <tr>
-                    <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }} colSpan={4}>
-                      Nessun partner trovato.
+        <div className="table-scroll gestionale-partner-table-wrap">
+          <table className="responsive-table partner-table gestionale-partner-table">
+            <thead>
+              <tr>
+                <th>Ragione Sociale</th>
+                <th>Telefono</th>
+                <th>Email</th>
+                <th>Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visiblePartners.map((partner) => {
+                const isSelected = selectedPartnerId === partner.id;
+                return (
+                  <tr
+                    key={partner.id}
+                    className={`gestionale-partner-row ${isSelected ? 'is-selected' : ''} ${partner.deleted ? 'is-deleted' : ''}`}
+                  >
+                    <td>{partner.ragioneSociale}</td>
+                    <td>{partner.telefono ?? '-'}</td>
+                    <td>{partner.email ?? '-'}</td>
+                    <td>
+                      <div className="table-actions gestionale-partner-table-actions">
+                        <button type="button" className="primary-button compact-button" onClick={() => selectPartner(partner.id)}>
+                          <ButtonContent icon={<SelectIcon />}>Seleziona</ButtonContent>
+                        </button>
+                        <button
+                          type="button"
+                          className="primary-button compact-button"
+                          onClick={() => {
+                            selectPartner(partner.id);
+                            setIsEditMode(true);
+                          }}
+                          disabled={partner.deleted}
+                        >
+                          <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
+                        </button>
+                      </div>
                     </td>
                   </tr>
-                ) : (
-                  visiblePartners.map((partner) => (
-                    <tr key={partner.id} style={selectedPartnerId === partner.id ? { background: '#eaf1f9' } : undefined}>
-                      <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>
-                        {partner.ragioneSociale} {partner.deleted ? '(cancellato)' : ''}
-                      </td>
-                      <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{partner.telefono ?? '-'}</td>
-                      <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{partner.email ?? '-'}</td>
-                      <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>
-                        <div className="table-actions" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                          <button type="button" className="logout-button compact-button" onClick={() => selectPartner(partner.id)}>
-                            <ButtonContent icon={<SelectIcon />}>Seleziona</ButtonContent>
-                          </button>
-                          <button
-                            type="button"
-                            className="primary-button compact-button"
-                            onClick={() => {
-                              selectPartner(partner.id);
-                              setIsEditMode(true);
-                            }}
-                            disabled={partner.deleted}
-                          >
-                            <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
+                );
+              })}
+            </tbody>
+          </table>
+          {loading && <p className="gestionale-partner-table-empty">Caricamento partner...</p>}
+          {!loading && visiblePartners.length === 0 && <p className="gestionale-partner-table-empty">Nessun partner trovato.</p>}
+        </div>
+
+        <div className="gestionale-partner-mobile-list-wrap">
+          <h4 className="gestionale-partner-mobile-list-title">Partner ({visiblePartners.length})</h4>
+
+          <div className="gestionale-partner-mobile-list">
+            {visiblePartners.map((partner) => {
+              const isSelected = selectedPartnerId === partner.id;
+              return (
+                <button
+                  key={`mobile-${partner.id}`}
+                  type="button"
+                  className={`gestionale-partner-mobile-item ${isSelected ? 'is-selected' : ''}`}
+                  onClick={() => selectPartner(partner.id)}
+                >
+                  <span className="gestionale-partner-mobile-icon" aria-hidden="true">{typeLabel(partner.type).charAt(0)}</span>
+
+                  <span className="gestionale-partner-mobile-main">
+                    <span className="gestionale-partner-mobile-name">{partner.ragioneSociale}</span>
+                    <span className="gestionale-partner-mobile-type">{typeLabel(partner.type)}</span>
+                  </span>
+
+                  <span className="gestionale-partner-mobile-chevron" aria-hidden="true">›</span>
+                </button>
+              );
+            })}
           </div>
-        )}
+
+          {loading && <p className="gestionale-partner-table-empty">Caricamento partner...</p>}
+          {!loading && visiblePartners.length === 0 && <p className="gestionale-partner-table-empty">Nessun partner trovato.</p>}
+        </div>
       </article>
 
       {selectedPartnerDetail && (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1013,19 +1013,25 @@ a:hover {
 }
 
 .tenant-search-field .form-input {
-  min-height: 52px;
-  border-radius: 12px;
-  padding-left: 48px;
+  min-height: 58px;
+  border: 1.5px solid #d0dcea;
+  border-radius: 14px;
+  padding: 12px 16px 12px 56px;
+  background: #ffffff;
+  color: #1e2d3d;
+  font-size: 16px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .tenant-search-icon {
   position: absolute;
   top: 50%;
-  left: 14px;
+  left: 12px;
   transform: translateY(-50%);
-  color: #67819d;
-  width: 20px;
-  height: 20px;
+  color: #8ca0b8;
+  width: 16px;
+  height: 16px;
 }
 
 .tenant-search-icon svg {
@@ -1510,11 +1516,11 @@ a:hover {
 .gestionale-partner-search-icon {
   position: absolute;
   top: 50%;
-  left: 14px;
-  width: 22px;
-  height: 22px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
   transform: translateY(-50%);
-  color: #6f829b;
+  color: #8ca0b8;
 }
 
 .gestionale-partner-search-icon svg {
@@ -1525,24 +1531,25 @@ a:hover {
 
 .gestionale-partner-search-input {
   width: 100%;
-  min-height: 46px;
-  border: 1px solid #ccd7e5;
-  border-radius: 10px;
-  padding: 10px 14px 10px 52px;
-  background: #f8fbff;
-  color: #243449;
-  font-size: 14px;
+  min-height: 58px;
+  border: 1.5px solid #d0dcea;
+  border-radius: 14px;
+  padding: 12px 16px 12px 56px;
+  background: #ffffff;
+  color: #1e2d3d;
+  font-size: 16px;
   font-weight: 500;
   font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .gestionale-partner-search-input::placeholder {
-  color: #6f829b;
+  color: #a0b0c3;
 }
 
 .gestionale-partner-search-input:focus {
-  outline: none;
-  border-color: #8fb4de;
+  border-color: #1e88e5;
   box-shadow: 0 0 0 3px rgba(30, 136, 229, 0.12);
 }
 
@@ -1592,8 +1599,12 @@ a:hover {
   border-bottom: 1px solid #e0e7f1;
   color: #273447;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
   vertical-align: middle;
+}
+
+.gestionale-partner-table tbody td:first-child {
+  font-weight: 700;
 }
 
 .gestionale-partner-row.is-selected {
@@ -1700,6 +1711,11 @@ a:hover {
   gap: 16px;
 }
 
+.gestionale-driver-informative-stack {
+  display: grid;
+  gap: 12px;
+}
+
 .gestionale-driver-kpi-card {
   border: 1px solid #e5e7eb;
   border-radius: 12px;
@@ -1766,7 +1782,7 @@ a:hover {
 .gestionale-driver-kpi-value {
   margin: auto 0 0;
   color: #111827;
-  font-size: 28px;
+  font-size: 26px;
   line-height: 1.1;
   font-weight: 700;
   text-align: center;
@@ -1815,11 +1831,11 @@ a:hover {
 .gestionale-driver-search-icon {
   position: absolute;
   top: 50%;
-  left: 14px;
-  width: 22px;
-  height: 22px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
   transform: translateY(-50%);
-  color: #6f829b;
+  color: #8ca0b8;
 }
 
 .gestionale-driver-search-icon svg {
@@ -1830,24 +1846,25 @@ a:hover {
 
 .gestionale-driver-search-input {
   width: 100%;
-  min-height: 46px;
-  border: 1px solid #ccd7e5;
-  border-radius: 10px;
-  padding: 10px 14px 10px 52px;
-  background: #f8fbff;
-  color: #243449;
-  font-size: 14px;
+  min-height: 58px;
+  border: 1.5px solid #d0dcea;
+  border-radius: 14px;
+  padding: 12px 16px 12px 56px;
+  background: #ffffff;
+  color: #1e2d3d;
+  font-size: 16px;
   font-weight: 500;
   font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .gestionale-driver-search-input::placeholder {
-  color: #6f829b;
+  color: #a0b0c3;
 }
 
 .gestionale-driver-search-input:focus {
-  outline: none;
-  border-color: #8fb4de;
+  border-color: #1e88e5;
   box-shadow: 0 0 0 3px rgba(30, 136, 229, 0.12);
 }
 
@@ -2101,7 +2118,7 @@ a:hover {
 
 .gestionale-driver-selected-name {
   margin: 0;
-  font-size: 29px;
+  font-size: 27px;
   line-height: 1.08;
   letter-spacing: -0.02em;
   color: #1e2b3d;
@@ -2462,7 +2479,7 @@ a:hover {
   }
 
   .gestionale-driver-kpi-value {
-    font-size: 22px;
+    font-size: 20px;
     line-height: 1;
     margin: 0;
     text-align: left;
@@ -2509,12 +2526,12 @@ a:hover {
 
   .gestionale-driver-mobile-search-icon {
     position: absolute;
-    left: 14px;
+    left: 12px;
     top: 50%;
     transform: translateY(-50%);
-    width: 22px;
-    height: 22px;
-    color: #7d8ea6;
+    width: 16px;
+    height: 16px;
+    color: #8ca0b8;
   }
 
   .gestionale-driver-mobile-search-icon svg {
@@ -2524,18 +2541,20 @@ a:hover {
 
   .gestionale-driver-mobile-search-input {
     width: 100%;
-    height: 52px;
-    border: 1px solid #ccd5e2;
-    border-radius: 12px;
-    padding: 0 14px 0 56px;
-    background: #f8fbff;
-    color: #34465d;
-    font-size: 14px;
+    min-height: 58px;
+    border: 1.5px solid #d0dcea;
+    border-radius: 14px;
+    padding: 12px 16px 12px 56px;
+    background: #ffffff;
+    color: #1e2d3d;
+    font-size: 16px;
     font-weight: 500;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
   }
 
   .gestionale-driver-mobile-search-input::placeholder {
-    color: #72869f;
+    color: #a0b0c3;
   }
 
   .gestionale-driver-mobile-filter-btn {
@@ -2781,7 +2800,7 @@ a:hover {
   }
 
   .gestionale-driver-selected-name {
-    font-size: 24px;
+    font-size: 22px;
   }
 
   .gestionale-driver-selected-meta-grid {
@@ -3975,9 +3994,10 @@ a:hover {
   border-radius: 14px;
   min-height: 58px;
   padding: 12px 44px 12px 18px;
-  font-size: 16px;
+  font-size: 17px;
   color: #1e2d3d;
   background: #ffffff;
+  text-transform: capitalize;
   outline: none;
   min-width: 180px;
   transition: border-color 0.15s, box-shadow 0.15s;
@@ -3994,10 +4014,11 @@ a:hover {
   border-radius: 15px;
   min-height: 58px;
   padding: 12px 16px 12px 18px;
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 500;
   color: #1f2937;
-  background: linear-gradient(180deg, #ffffff 0%, #fbfcfe 100%);
+  background: #ffffff;
+  text-transform: capitalize;
   outline: none;
   display: inline-flex;
   align-items: center;
@@ -4009,7 +4030,7 @@ a:hover {
 }
 
 .services-filter-dropdown-trigger:hover {
-  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  background: #f8fafc;
 }
 
 .services-filter-dropdown-trigger:focus {
@@ -4068,9 +4089,10 @@ a:hover {
   background: transparent;
   color: #1f2937;
   padding: 12px 14px;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 500;
   text-align: left;
+  text-transform: capitalize;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -4120,6 +4142,83 @@ a:hover {
 .services-filter-input:focus {
   border-color: #1e88e5;
   box-shadow: 0 0 0 3px rgba(30, 136, 229, 0.12);
+}
+
+/* === Portal filters system (aligned to /services) === */
+.portal-filters-surface {
+  padding: 18px 26px;
+  margin-top: 0;
+  border: 1px solid #d9e1eb;
+  border-radius: 14px;
+  background: #f8fafc;
+}
+
+.portal-filters-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: end;
+}
+
+.portal-filters-grid > label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #6b7f9d;
+  padding-left: 2px;
+}
+
+.portal-filters-grid .form-input,
+.portal-filters-grid .form-input[type='date'],
+.finance-movements-filter-field .form-input {
+  min-height: 58px;
+  border: 1.5px solid #d0dcea;
+  border-radius: 14px;
+  padding: 12px 16px;
+  font-size: 17px;
+  color: #1e2d3d;
+  background: #ffffff;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.portal-filters-grid select.form-input,
+.finance-movements-filter-field select.form-input {
+  padding-right: 44px;
+  text-transform: capitalize;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24'%3E%3Cpath d='M6 9l6 6 6-6' fill='none' stroke='%236e84a0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+}
+
+.portal-filters-grid .form-input:focus,
+.finance-movements-filter-field .form-input:focus,
+.tenant-search-field .form-input:focus,
+.gestionale-partner-search-input:focus,
+.gestionale-driver-search-input:focus,
+.gestionale-driver-mobile-search-input:focus {
+  border-color: #1e88e5;
+  box-shadow: 0 0 0 3px rgba(30, 136, 229, 0.12);
+}
+
+.tenant-search-field .form-input,
+.gestionale-partner-search-input,
+.gestionale-driver-search-input,
+.gestionale-driver-mobile-search-input {
+  border-width: 1.5px;
+  border-color: #d0dcea;
+  border-radius: 14px;
+  min-height: 58px;
+  background: #ffffff;
+}
+
+.finance-movements-filters-card .finance-movements-filter-search .form-input {
+  padding-left: 42px;
 }
 
 .services-filter-unassigned-btn {
@@ -4299,6 +4398,342 @@ a:hover {
 
 .finance-bar.category {
   background: linear-gradient(90deg, #ef6c00, #ffb300);
+}
+
+.finance-movements-filters-card {
+  display: grid;
+  gap: 12px;
+}
+
+.finance-movements-filters-row {
+  display: grid;
+  grid-template-columns: minmax(260px, 1.6fr) repeat(3, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.finance-movements-filters-row-dates {
+  grid-template-columns: repeat(2, minmax(170px, 1fr));
+  max-width: 420px;
+}
+
+.finance-movements-filter-field {
+  display: block;
+}
+
+.finance-movements-filter-search {
+  position: relative;
+}
+
+.finance-movements-filter-search .form-input {
+  padding-left: 42px;
+}
+
+.finance-movements-filter-search-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  color: #6d809a;
+  display: inline-grid;
+  place-items: center;
+  pointer-events: none;
+}
+
+.finance-movements-filter-search-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.finance-movements-active-filters {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.finance-movements-filter-chip {
+  border: 1px solid #d8e1ec;
+  background: #eef2f6;
+  color: #283545;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.finance-movements-filter-chip:hover {
+  background: #e6edf5;
+}
+
+.finance-movements-filter-chip span {
+  font-size: 16px;
+  line-height: 1;
+  font-weight: 500;
+}
+
+.finance-movements-filters-clear-all {
+  border: none;
+  background: transparent;
+  color: #1f2a37;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.finance-movements-filters-clear-all:hover {
+  color: #0c5a99;
+}
+
+@media (max-width: 1180px) {
+  .finance-movements-filters-row {
+    grid-template-columns: repeat(2, minmax(180px, 1fr));
+  }
+
+  .finance-movements-filters-row-dates {
+    max-width: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .finance-movements-filters-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Finance movements filters header (mobile toggle) ─────────── */
+.finance-movements-filters-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.finance-movements-filters-toggle {
+  display: none;
+  border: 1px solid #c8d7ea;
+  border-radius: 10px;
+  padding: 7px 14px;
+  background: #f0f6fc;
+  color: #1f4f84;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  gap: 6px;
+  align-items: center;
+}
+
+/* ── Finance mobile card list ─────────────────────────────────── */
+.finance-movements-mobile-list {
+  display: none;
+}
+
+.finance-movement-card {
+  background: #ffffff;
+  border: 1px solid #c8d5e7;
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: 0 2px 8px rgba(15, 52, 87, 0.07);
+  display: grid;
+  gap: 10px;
+}
+
+.finance-movement-card.is-voided {
+  opacity: 0.7;
+}
+
+.finance-movement-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.finance-movement-card-badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.finance-movement-card-desc {
+  font-size: 14px;
+  color: #243142;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.finance-movement-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.finance-movement-card-date {
+  font-size: 13px;
+  font-weight: 700;
+  color: #4a6278;
+  white-space: nowrap;
+}
+
+.finance-movement-card-category {
+  font-size: 12px;
+  font-weight: 700;
+  color: #647992;
+  letter-spacing: 0.03em;
+  background: #eef3f8;
+  border-radius: 6px;
+  padding: 2px 8px;
+}
+
+.finance-movement-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.finance-movements-filters-body {
+  display: grid;
+  gap: 12px;
+}
+
+
+.finance-movements-table-wrap {
+  overflow-x: auto;
+  border: 1px solid #dce4ef;
+  border-radius: 12px;
+  background: #ffffff;
+}
+
+.finance-movements-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 980px;
+}
+
+.finance-movements-th {
+  text-align: left;
+  border-bottom: 1px solid #dce4ef;
+  padding: 16px 18px;
+  font-size: 12px;
+  color: #60748f;
+  font-weight: 700;
+}
+
+.finance-movements-th-amount {
+  text-align: right;
+}
+
+.finance-movements-th-actions {
+  text-align: center;
+  width: 76px;
+}
+
+.finance-movements-td {
+  border-bottom: 1px solid #e9eef5;
+  padding: 14px 18px;
+  color: #243142;
+  font-size: 13px;
+}
+
+.finance-movements-table tbody tr:last-child .finance-movements-td {
+  border-bottom: none;
+}
+
+.finance-movements-date {
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.finance-movements-category {
+  color: #647992;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.finance-movements-description {
+  min-width: 360px;
+}
+
+.finance-movements-amount-cell {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.finance-movements-amount {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+.finance-movements-amount-revenue {
+  color: #2ca557;
+}
+
+.finance-movements-amount-cost {
+  color: #e53935;
+}
+
+.finance-movements-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0 14px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.finance-movements-pill-revenue {
+  background: #2ca557;
+  color: #ffffff;
+}
+
+.finance-movements-pill-cost {
+  background: #e53935;
+  color: #ffffff;
+}
+
+.finance-movements-pill-auto {
+  background: #2b9ad9;
+  color: #ffffff;
+}
+
+.finance-movements-pill-manual {
+  background: #f2f5f8;
+  color: #344150;
+  border: 1px solid #d4dce7;
+}
+
+.finance-movements-pill-voided {
+  background: #fce8e7;
+  color: #b63a36;
+  border: 1px solid #f0c8c6;
+}
+
+.finance-movements-actions-cell {
+  text-align: center;
+}
+
+.finance-movements-empty {
+  padding: 16px 18px;
+  color: #5f7693;
+  font-size: 14px;
+}
+
+.finance-movements-actions-cell .services-row-menu {
+  display: inline-block;
 }
 
 .print-page {
@@ -4606,7 +5041,7 @@ a:hover {
   color: #6b7280;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 960px) {
   .services-stat-cards {
     grid-template-columns: 1fr;
   }
@@ -4696,7 +5131,7 @@ a:hover {
   color: #ffffff;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 960px) {
   .services-selected-detail {
     padding: 12px;
     border-radius: 16px;
@@ -5108,6 +5543,46 @@ a:hover {
     display: none;
   }
 
+  /* Finance movements mobile */
+  .finance-movements-filters-toggle {
+    display: inline-flex;
+  }
+
+  .finance-movements-filters-body.is-hidden-mobile {
+    display: none !important;
+  }
+
+  .finance-movements-desktop-table {
+    display: none;
+  }
+
+  .finance-movements-mobile-list {
+    display: grid;
+    gap: 12px;
+    margin-top: 8px;
+  }
+
+  .finance-movements-filters-header {
+    margin-bottom: 0;
+  }
+
+  /* Riduci il testo filtri quando la tendina e aperta */
+  .services-filters-grid:not(.is-hidden-mobile) .services-filter-label,
+  .services-filters-grid:not(.is-hidden-mobile) .services-filter-select,
+  .services-filters-grid:not(.is-hidden-mobile) .services-filter-dropdown-trigger,
+  .services-filters-grid:not(.is-hidden-mobile) .services-filter-input,
+  .services-filters-grid:not(.is-hidden-mobile) .services-filter-unassigned-btn,
+  .services-filters-grid:not(.is-hidden-mobile) .services-search-input,
+  .services-filters-grid:not(.is-hidden-mobile) .services-filter-dropdown-option {
+    font-size: 13px;
+  }
+
+  .finance-movements-filters-body:not(.is-hidden-mobile) .form-input,
+  .finance-movements-filters-body:not(.is-hidden-mobile) .finance-movements-filter-chip,
+  .finance-movements-filters-body:not(.is-hidden-mobile) .finance-movements-filters-clear-all {
+    font-size: 13px;
+  }
+
   .services-mobile-list {
     display: grid;
     gap: 12px;
@@ -5342,6 +5817,7 @@ a:hover {
   }
 
   .responsive-filters-grid,
+  .portal-filters-grid,
   .responsive-form-grid {
     grid-template-columns: 1fr !important;
   }
@@ -5561,6 +6037,59 @@ a:hover {
       margin: 16px 0 12px;
       line-height: 1;
     }
+}
+
+/* ── Vehicle modal ── */
+.fleet-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 30, 50, 0.45);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.fleet-modal {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 8px 40px rgba(15, 30, 50, 0.22);
+  padding: 28px 24px 24px;
+  width: 100%;
+  max-width: 520px;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+}
+
+.fleet-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.fleet-modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #1f2b3b;
+}
+
+.fleet-modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 20px;
+  color: #7a90aa;
+  border-radius: 6px;
+  line-height: 1;
+}
+
+.fleet-modal-close:hover {
+  background: #f0f4f8;
+  color: #1f2b3b;
 }
 
 @page {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -242,6 +242,10 @@ a:hover {
   opacity: 1;
 }
 
+.fleet-inline-notice {
+  margin-top: 8px;
+}
+
 /* ── Storico partner servizio (sph) ─────────────────────────── */
 .sph-card {
   margin-top: 18px;
@@ -1494,6 +1498,52 @@ a:hover {
   gap: 12px;
   flex-wrap: nowrap;
   margin-left: auto;
+}
+
+.gestionale-partner-search {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: clamp(320px, 38vw, 520px);
+}
+
+.gestionale-partner-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  width: 22px;
+  height: 22px;
+  transform: translateY(-50%);
+  color: #6f829b;
+}
+
+.gestionale-partner-search-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.gestionale-partner-search-input {
+  width: 100%;
+  min-height: 46px;
+  border: 1px solid #ccd7e5;
+  border-radius: 10px;
+  padding: 10px 14px 10px 52px;
+  background: #f8fbff;
+  color: #243449;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+}
+
+.gestionale-partner-search-input::placeholder {
+  color: #6f829b;
+}
+
+.gestionale-partner-search-input:focus {
+  outline: none;
+  border-color: #8fb4de;
+  box-shadow: 0 0 0 3px rgba(30, 136, 229, 0.12);
 }
 
 .gestionale-partner-include-toggle {
@@ -5488,6 +5538,11 @@ a:hover {
     .gestionale-partner-toolbar-actions {
       width: 100%;
       justify-content: space-between;
+      flex-wrap: wrap;
+    }
+
+    .gestionale-partner-search {
+      width: 100%;
     }
 
     .gestionale-partner-table-wrap {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -532,7 +532,7 @@ a:hover {
   }
 }
 
-@media (max-width: 760px) {
+@media (max-width: 1024px) {
   .sph-desktop-list {
     display: none;
   }
@@ -1462,6 +1462,188 @@ a:hover {
   flex-wrap: wrap;
 }
 
+/* ── Gestionale Partner List ────────────────────────────────── */
+.gestionale-partner-list-card {
+  border: 1px solid #d8e2ef;
+  border-radius: 16px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.gestionale-partner-toolbar {
+  padding: 16px 20px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: nowrap;
+}
+
+.gestionale-partner-toolbar h3 {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  color: #1f2b3b;
+}
+
+.gestionale-partner-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: nowrap;
+  margin-left: auto;
+}
+
+.gestionale-partner-include-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 46px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  color: #1f2b3b;
+  white-space: nowrap;
+}
+
+.gestionale-partner-include-toggle input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: #3b82f6;
+  cursor: pointer;
+}
+
+.gestionale-partner-table-wrap {
+  margin-top: 0;
+}
+
+.gestionale-partner-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 800px;
+}
+
+.gestionale-partner-table thead th {
+  text-align: left;
+  padding: 14px 20px;
+  border-top: 1px solid #e0e7f1;
+  border-bottom: 1px solid #dce4ef;
+  color: #6a7f9a;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.gestionale-partner-table tbody td {
+  padding: 18px 20px;
+  border-bottom: 1px solid #e0e7f1;
+  color: #273447;
+  font-size: 14px;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.gestionale-partner-row.is-selected {
+  background: #eaf4ff;
+}
+
+.gestionale-partner-row.is-deleted {
+  color: #7f8ea3;
+}
+
+.gestionale-partner-table-actions {
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: nowrap;
+}
+
+.gestionale-partner-table-actions .compact-button {
+  min-height: 38px;
+  font-size: 14px;
+  font-weight: 700;
+  padding: 7px 12px;
+}
+
+.gestionale-partner-table-empty {
+  margin: 0;
+  padding: 14px 20px 18px;
+  color: #6b7f9d;
+}
+
+.gestionale-partner-mobile-list-wrap {
+  display: none;
+}
+
+.gestionale-partner-mobile-list {
+  display: grid;
+  gap: 12px;
+}
+
+.gestionale-partner-mobile-item {
+  width: 100%;
+  border: 1px solid #d5dee9;
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 14px 16px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.gestionale-partner-mobile-item.is-selected {
+  border-color: #8eb4de;
+  background: #eef6ff;
+}
+
+.gestionale-partner-mobile-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: #edf2f8;
+  color: #2d66b3;
+  display: inline-grid;
+  place-items: center;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.gestionale-partner-mobile-main {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.gestionale-partner-mobile-name {
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  color: #1f2b3b;
+}
+
+.gestionale-partner-mobile-type {
+  font-size: 13px;
+  color: #6d819d;
+  font-weight: 500;
+}
+
+.gestionale-partner-mobile-chevron {
+  width: 24px;
+  height: 24px;
+  color: #7f92aa;
+  display: inline-grid;
+  place-items: center;
+  font-size: 24px;
+  line-height: 1;
+}
+
 .gestionale-driver-kpi-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -2192,7 +2374,7 @@ a:hover {
   cursor: not-allowed;
 }
 
-@media (max-width: 760px) {
+@media (max-width: 1024px) {
   .gestionale-driver-kpi-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
@@ -5298,6 +5480,32 @@ a:hover {
   .driver-profile-panel .dashboard-card p {
     overflow-wrap: anywhere;
   }
+
+    .gestionale-partner-toolbar {
+      flex-wrap: wrap;
+    }
+
+    .gestionale-partner-toolbar-actions {
+      width: 100%;
+      justify-content: space-between;
+    }
+
+    .gestionale-partner-table-wrap {
+      display: none;
+    }
+
+    .gestionale-partner-mobile-list-wrap {
+      display: block;
+      padding: 0 20px 20px;
+    }
+
+    .gestionale-partner-mobile-list-title {
+      font-size: 16px;
+      font-weight: 700;
+      color: #1f2b3b;
+      margin: 16px 0 12px;
+      line-height: 1;
+    }
 }
 
 @page {

--- a/frontend/components/admin-tenants-panel.tsx
+++ b/frontend/components/admin-tenants-panel.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { AddIcon, ButtonContent, CancelIcon, CopyIcon, SaveIcon, SearchIcon } from './action-icons';
+import { StatusNotice } from './status-notice';
 
 type TenantOperationalStatus = 'ACTIVE' | 'SUSPENDED';
 type SubscriptionStatus = 'TRIAL' | 'ACTIVE' | 'PAST_DUE' | 'CANCELED';
@@ -471,8 +472,8 @@ export function AdminTenantsPanel() {
         </label>
       </form>
 
-      {error && <p className="error-text">{error}</p>}
-      {success && <p className="success-text">{success}</p>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
+      {success && <StatusNotice tone="success">{success}</StatusNotice>}
 
       {selectedTenant && (
         <TenantDetailView

--- a/frontend/components/admin-users-panel.tsx
+++ b/frontend/components/admin-users-panel.tsx
@@ -191,7 +191,7 @@ export function AdminUsersPanel() {
         {success && <StatusNotice tone="success">{success}</StatusNotice>}
 
         {/* Filtri */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10, marginBottom: 12 }}>
+        <div className="portal-filters-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10, marginBottom: 12 }}>
           <label>
             User ID
             <input className="form-input" value={filterUserId} onChange={(e) => setFilterUserId(e.target.value)} placeholder="cerca..." />
@@ -392,7 +392,7 @@ export function AdminUsersPanel() {
 
         {journalOpen && (
           <>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10, marginBottom: 12 }}>
+            <div className="portal-filters-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10, marginBottom: 12 }}>
               <label>
                 Data modifica
                 <input

--- a/frontend/components/admin-users-panel.tsx
+++ b/frontend/components/admin-users-panel.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { ButtonContent, CancelIcon, EditIcon, FilterIcon, JournalIcon, LockIcon, ResetIcon, SaveIcon } from './action-icons';
 import { PasswordInput } from './password-input';
+import { StatusNotice } from './status-notice';
 
 type UserRole = 'ADMIN' | 'GESTIONALE' | 'DRIVER';
 
@@ -186,8 +187,8 @@ export function AdminUsersPanel() {
     <section style={{ display: 'grid', gap: 16 }}>
       <article className="dashboard-card">
         <h3>Elenco utenti</h3>
-        {error && <p className="error-text">{error}</p>}
-        {success && <p className="success-text">{success}</p>}
+        {error && <StatusNotice tone="error">{error}</StatusNotice>}
+        {success && <StatusNotice tone="success">{success}</StatusNotice>}
 
         {/* Filtri */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10, marginBottom: 12 }}>
@@ -432,7 +433,7 @@ export function AdminUsersPanel() {
               </button>
             </div>
 
-            {journalError && <p className="error-text">{journalError}</p>}
+            {journalError && <StatusNotice tone="error">{journalError}</StatusNotice>}
 
             {journalLoading ? (
               <p>Caricamento journal...</p>

--- a/frontend/components/calendar-dashboard.tsx
+++ b/frontend/components/calendar-dashboard.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeftIcon, ArrowRightIcon, ButtonContent, LockIcon, OpenIcon, SelectIcon, TodayIcon } from './action-icons';
 import { formatCurrencyEUR } from '../lib/currency';
+import { StatusNotice } from './status-notice';
 
 type ViewMode = 'month' | 'week' | 'day';
 type ServiceType = 'TRANSFER' | 'TOUR';
@@ -713,8 +714,8 @@ export function CalendarDashboard({ driverMode = false }: CalendarDashboardProps
         </div>
       </article>
 
-      {error && <p className="error-text">{error}</p>}
-      {success && <p className="success-text">{success}</p>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
+      {success && <StatusNotice tone="success">{success}</StatusNotice>}
       {loading && <p>Caricamento calendario...</p>}
 
       {!loading && !error && (

--- a/frontend/components/calendar-dashboard.tsx
+++ b/frontend/components/calendar-dashboard.tsx
@@ -667,7 +667,7 @@ export function CalendarDashboard({ driverMode = false }: CalendarDashboardProps
           </div>
         </div>
 
-        <div className="responsive-filters-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10, marginTop: 12 }}>
+        <div className="responsive-filters-grid portal-filters-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10, marginTop: 12 }}>
           {!driverMode && (
             <label>
               Driver

--- a/frontend/components/driver-profile-panel.tsx
+++ b/frontend/components/driver-profile-panel.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useState } from 'react';
 import { AddIcon, ButtonContent, CancelIcon, DeleteIcon, EditIcon, SaveIcon } from './action-icons';
+import { StatusNotice } from './status-notice';
 
 type LicenseType = 'AM' | 'A1' | 'A2' | 'A' | 'B' | 'BE' | 'C' | 'CE' | 'D' | 'DE' | 'CQC';
 
@@ -220,13 +221,13 @@ export function DriverProfilePanel() {
   }
 
   if (!profile || !form) {
-    return <p className="error-text">Profilo non disponibile.</p>;
+    return <StatusNotice tone="error">Profilo non disponibile.</StatusNotice>;
   }
 
   return (
     <section className="responsive-panel driver-profile-panel" style={{ display: 'grid', gap: 16 }}>
-      {error && <p className="error-text">{error}</p>}
-      {success && <p className="success-text">{success}</p>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
+      {success && <StatusNotice tone="success">{success}</StatusNotice>}
 
       {/* Card patenti in scadenza */}
       {(() => {

--- a/frontend/components/filter-dropdown.tsx
+++ b/frontend/components/filter-dropdown.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useState } from 'react';
+
+export type FilterDropdownOption = {
+  value: string;
+  label: string;
+};
+
+export function FilterDropdown({
+  label,
+  value,
+  options,
+  onChange,
+  className,
+}: {
+  label: string;
+  value: string;
+  options: FilterDropdownOption[];
+  onChange: (nextValue: string) => void;
+  className?: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  const selectedOption = options.find((option) => option.value === value) ?? options[0];
+
+  return (
+    <div className={`services-filter-dropdown ${className ?? ''}`.trim()} ref={containerRef}>
+      <button
+        type="button"
+        className={`services-filter-dropdown-trigger ${isOpen ? 'is-open' : ''}`}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <span className="services-filter-dropdown-value">{selectedOption?.label ?? label}</span>
+        <span className="services-filter-dropdown-chevron" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path
+              d="m6 9 6 6 6-6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="services-filter-dropdown-menu" role="listbox" aria-label={label}>
+          {options.map((option) => {
+            const isSelected = option.value === value;
+            return (
+              <button
+                key={option.value || '__all__'}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                className={`services-filter-dropdown-option ${isSelected ? 'is-selected' : ''}`}
+                onClick={() => {
+                  onChange(option.value);
+                  setIsOpen(false);
+                }}
+              >
+                <span className="services-filter-dropdown-check" aria-hidden="true">
+                  {isSelected ? (
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path
+                        d="m5 12 4.2 4.2L19 6.8"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2.2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  ) : null}
+                </span>
+                <span className="services-filter-dropdown-option-label">{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/fleet-deadlines-alerts.tsx
+++ b/frontend/components/fleet-deadlines-alerts.tsx
@@ -217,6 +217,10 @@ export function FleetDeadlinesAlerts({
     return 'Altro';
   }
 
+  if (!loading && !error && orderedItems.length === 0) {
+    return null;
+  }
+
   return (
     <article className="dashboard-card">
       <button

--- a/frontend/components/fleet-deadlines-alerts.tsx
+++ b/frontend/components/fleet-deadlines-alerts.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
+import { StatusNotice } from './status-notice';
 
 type DeadlineType = 'BOLLO' | 'ASSICURAZIONE' | 'REVISIONE' | 'TAGLIANDO' | 'ALTRO';
 type DeadlineStatus = 'DA_ESEGUIRE' | 'IN_SCADENZA' | 'SCADUTA' | 'PAGATA' | 'ESEGUITA' | 'ANNULLATA';
@@ -241,7 +242,7 @@ export function FleetDeadlinesAlerts({
           {loading ? (
             <p>Caricamento allarmi...</p>
           ) : error ? (
-            <p className="error-text">{error}</p>
+            <StatusNotice tone="error">{error}</StatusNotice>
           ) : orderedItems.length === 0 ? (
             <p>Nessuna scadenza aperta.</p>
           ) : (

--- a/frontend/components/fleet-deadlines-panel.tsx
+++ b/frontend/components/fleet-deadlines-panel.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { AddIcon, ButtonContent, CancelIcon, DeleteIcon, EditIcon, LockIcon, ResetIcon, SaveIcon } from './action-icons';
 import { StatusNotice } from './status-notice';
+import { FilterDropdown } from './filter-dropdown';
 
 type DeadlineType = 'BOLLO' | 'ASSICURAZIONE' | 'REVISIONE' | 'TAGLIANDO' | 'ALTRO';
 type DeadlineStatus = 'DA_ESEGUIRE' | 'IN_SCADENZA' | 'SCADUTA' | 'PAGATA' | 'ESEGUITA' | 'ANNULLATA';
@@ -292,29 +293,33 @@ export function FleetDeadlinesPanel() {
           </button>
         </div>
 
-        <div className="responsive-filters-grid" style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', marginTop: 8 }}>
-          <label>
-            Vista
-            <select className="form-input" value={viewMode} onChange={(event) => setViewMode(event.target.value as ViewMode)}>
-              <option value="vehicle">Storico veicolo</option>
-              <option value="upcoming">In scadenza</option>
-              <option value="overdue">Scadute</option>
-            </select>
-          </label>
+        <div className="responsive-filters-grid portal-filters-grid" style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', marginTop: 8 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <span style={{ fontSize: 14, fontWeight: 600, color: '#6b7f9d', paddingLeft: 2 }}>Vista</span>
+            <FilterDropdown
+              label="Vista"
+              value={viewMode}
+              options={[
+                { value: 'vehicle', label: 'Storico veicolo' },
+                { value: 'upcoming', label: 'In scadenza' },
+                { value: 'overdue', label: 'Scadute' },
+              ]}
+              onChange={(v) => setViewMode(v as ViewMode)}
+            />
+          </div>
 
-          <label>
-            Veicolo
-            <select
-              className="form-input"
-              value={selectedVehicleId}
-              onChange={(event) => setSelectedVehicleId(event.target.value ? Number(event.target.value) : '')}
-            >
-              <option value="">Seleziona...</option>
-              {vehicles.map((vehicle) => (
-                <option key={vehicle.id} value={vehicle.id}>{vehicle.plate}</option>
-              ))}
-            </select>
-          </label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <span style={{ fontSize: 14, fontWeight: 600, color: '#6b7f9d', paddingLeft: 2 }}>Veicolo</span>
+            <FilterDropdown
+              label="Veicolo"
+              value={selectedVehicleId !== '' ? String(selectedVehicleId) : ''}
+              options={[
+                { value: '', label: 'Seleziona...' },
+                ...vehicles.map((vehicle) => ({ value: String(vehicle.id), label: vehicle.plate })),
+              ]}
+              onChange={(v) => setSelectedVehicleId(v ? Number(v) : '')}
+            />
+          </div>
 
           {viewMode === 'upcoming' && (
             <label>

--- a/frontend/components/fleet-deadlines-panel.tsx
+++ b/frontend/components/fleet-deadlines-panel.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { AddIcon, ButtonContent, CancelIcon, DeleteIcon, EditIcon, LockIcon, ResetIcon, SaveIcon } from './action-icons';
+import { StatusNotice } from './status-notice';
 
 type DeadlineType = 'BOLLO' | 'ASSICURAZIONE' | 'REVISIONE' | 'TAGLIANDO' | 'ALTRO';
 type DeadlineStatus = 'DA_ESEGUIRE' | 'IN_SCADENZA' | 'SCADUTA' | 'PAGATA' | 'ESEGUITA' | 'ANNULLATA';
@@ -418,8 +419,8 @@ export function FleetDeadlinesPanel() {
           </form>
         )}
 
-        {error && <p className="error-text" style={{ marginTop: 8 }}>{error}</p>}
-        {success && <p className="success-text" style={{ marginTop: 8 }}>{success}</p>}
+        {error && <StatusNotice tone="error" className="fleet-inline-notice">{error}</StatusNotice>}
+        {success && <StatusNotice tone="success" className="fleet-inline-notice">{success}</StatusNotice>}
       </article>
 
       <article className="dashboard-card">

--- a/frontend/components/fleet-vehicle-management.tsx
+++ b/frontend/components/fleet-vehicle-management.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 import { AddIcon, ButtonContent, CancelIcon, DeleteIcon, EditIcon, FilterIcon, LockIcon, ResetIcon, SaveIcon, SelectIcon } from './action-icons';
 import { StatusNotice } from './status-notice';
+import { FilterDropdown } from './filter-dropdown';
+import { FleetDeadlinesAlerts } from './fleet-deadlines-alerts';
 
 type VehicleType = 'SEDAN' | 'VAN' | 'MINIBUS' | 'SUV' | 'OTHER';
 type DeadlineType = 'BOLLO' | 'ASSICURAZIONE' | 'REVISIONE' | 'TAGLIANDO' | 'ALTRO';
@@ -218,8 +220,9 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
   const [selectedVehicleId, setSelectedVehicleId] = useState<number | ''>('');
   const [detail, setDetail] = useState<VehicleDetail | null>(null);
   const [loading, setLoading] = useState(false);
-  const [showCreateVehicleForm, setShowCreateVehicleForm] = useState(false);
-  const [showFiltersCard, setShowFiltersCard] = useState(false);
+  const [vehicleModal, setVehicleModal] = useState<null | 'create' | 'edit'>(null);
+  const vehicleModalRef = useRef<HTMLDivElement>(null);
+  const [vehicleFiltersOpen, setVehicleFiltersOpen] = useState(false);
   const [plateFilter, setPlateFilter] = useState('');
   const [typeFilter, setTypeFilter] = useState<'ALL' | VehicleType>('ALL');
   const [seatsFilter, setSeatsFilter] = useState('');
@@ -231,10 +234,9 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
   const [unavailabilities, setUnavailabilities] = useState<UnavailabilityItem[]>([]);
   const [unavailabilityForm, setUnavailabilityForm] = useState<UnavailabilityFormState>(defaultUnavailabilityForm);
 
-  const [showOccurrenceForm, setShowOccurrenceForm] = useState(false);
-  const [showPlanForm, setShowPlanForm] = useState(false);
-  const [showUnavailabilityForm, setShowUnavailabilityForm] = useState(false);
-  const [showVehicleForm, setShowVehicleForm] = useState(false);
+  const [occurrenceModalOpen, setOccurrenceModalOpen] = useState(false);
+  const [planModalOpen, setPlanModalOpen] = useState(false);
+  const [unavailabilityModalOpen, setUnavailabilityModalOpen] = useState(false);
   const [editingOccurrenceId, setEditingOccurrenceId] = useState<number | null>(null);
   const [editingPlanId, setEditingPlanId] = useState<number | null>(null);
   const [editingUnavailabilityId, setEditingUnavailabilityId] = useState<number | null>(null);
@@ -271,7 +273,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
     if (selectedVehicleId && !items.some((item) => item.id === selectedVehicleId)) {
       setSelectedVehicleId('');
       setDetail(null);
-      setShowVehicleForm(false);
+      setVehicleModal(null);
     }
   }
 
@@ -384,7 +386,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
     }
 
     setSuccess('Dati veicolo aggiornati');
-    setShowVehicleForm(false);
+    setVehicleModal(null);
     await loadVehicles();
     await loadVehicleDetail(selectedVehicleId);
   }
@@ -414,7 +416,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
 
     setSuccess('Veicolo creato');
     setNewVehicleForm({ plate: '', seats: '', type: 'SEDAN', notes: '' });
-    setShowCreateVehicleForm(true);
+    setVehicleModal(null);
 
     await loadVehicles();
   }
@@ -427,9 +429,37 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
     return 'Altro';
   }
 
+  function resetVehicleFilters() {
+    setPlateFilter('');
+    setTypeFilter('ALL');
+    setSeatsFilter('');
+  }
+
+  const activeVehicleFilterChips: { key: string; label: string; onRemove: () => void }[] = [];
+  if (plateFilter.trim()) {
+    activeVehicleFilterChips.push({
+      key: 'plate',
+      label: `Targa: ${plateFilter.trim()}`,
+      onRemove: () => setPlateFilter('')
+    });
+  }
+  if (typeFilter !== 'ALL') {
+    activeVehicleFilterChips.push({
+      key: 'type',
+      label: `Tipo: ${vehicleTypeLabel(typeFilter)}`,
+      onRemove: () => setTypeFilter('ALL')
+    });
+  }
+  if (seatsFilter.trim()) {
+    activeVehicleFilterChips.push({
+      key: 'seats',
+      label: `Posti: ${seatsFilter.trim()}`,
+      onRemove: () => setSeatsFilter('')
+    });
+  }
+
   function selectVehicle(vehicleId: number) {
     setSelectedVehicleId(vehicleId);
-    setShowVehicleForm(false);
   }
 
   function editVehicle(vehicle: VehicleItem) {
@@ -440,7 +470,68 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
       type: vehicle.type,
       notes: vehicle.notes ?? ''
     });
-    setShowVehicleForm(true);
+    setVehicleModal('edit');
+  }
+
+  function openOccurrenceCreateModal() {
+    setEditingOccurrenceId(null);
+    setOccurrenceForm(defaultOccurrenceForm);
+    setOccurrenceModalOpen(true);
+  }
+
+  function openOccurrenceEditModal(item: OccurrenceItem) {
+    setEditingOccurrenceId(item.id);
+    setOccurrenceForm({
+      planId: item.planId ?? '',
+      type: item.type,
+      title: item.title,
+      description: item.description ?? '',
+      dueDate: item.dueDate,
+      status: item.status,
+      cost: String(item.cost),
+      currency: item.currency,
+      notes: item.notes ?? '',
+      paymentDate: item.paymentDate ?? '',
+      executionDate: item.executionDate ?? ''
+    });
+    setOccurrenceModalOpen(true);
+  }
+
+  function openPlanCreateModal() {
+    setEditingPlanId(null);
+    setPlanForm(defaultPlanForm);
+    setPlanModalOpen(true);
+  }
+
+  function openPlanEditModal(item: PlanItem) {
+    setEditingPlanId(item.id);
+    setPlanForm({
+      type: item.type,
+      title: item.title,
+      description: item.description ?? '',
+      recurrenceMonths: String(item.recurrenceMonths),
+      nextDueDate: item.nextDueDate,
+      standardCost: String(item.standardCost),
+      currency: item.currency,
+      notes: item.notes ?? ''
+    });
+    setPlanModalOpen(true);
+  }
+
+  function openUnavailabilityCreateModal() {
+    setEditingUnavailabilityId(null);
+    setUnavailabilityForm(defaultUnavailabilityForm);
+    setUnavailabilityModalOpen(true);
+  }
+
+  function openUnavailabilityEditModal(item: UnavailabilityItem) {
+    setEditingUnavailabilityId(item.id);
+    setUnavailabilityForm({
+      startDate: item.startDate,
+      endDate: item.endDate,
+      reason: item.reason
+    });
+    setUnavailabilityModalOpen(true);
   }
 
   async function saveOccurrence(event: FormEvent<HTMLFormElement>) {
@@ -483,7 +574,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
     setSuccess(editingOccurrenceId ? 'Occorrenza aggiornata' : 'Occorrenza creata');
     setOccurrenceForm(defaultOccurrenceForm);
     setEditingOccurrenceId(null);
-    setShowOccurrenceForm(true);
+    setOccurrenceModalOpen(false);
     refreshFleetAlertBadge();
     await loadVehicleDetail(selectedVehicleId);
   }
@@ -525,7 +616,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
     setSuccess(editingPlanId ? 'Piano aggiornato' : 'Piano creato');
     setPlanForm(defaultPlanForm);
     setEditingPlanId(null);
-    setShowPlanForm(true);
+    setPlanModalOpen(false);
     refreshFleetAlertBadge();
     await loadVehicleDetail(selectedVehicleId);
   }
@@ -634,7 +725,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
     setSuccess(editingUnavailabilityId ? 'Manutenzione aggiornata' : 'Manutenzione inserita');
     setEditingUnavailabilityId(null);
     setUnavailabilityForm(defaultUnavailabilityForm);
-    setShowUnavailabilityForm(true);
+    setUnavailabilityModalOpen(false);
     await loadVehicleUnavailabilities(selectedVehicleId);
   }
 
@@ -657,6 +748,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
     if (editingUnavailabilityId === unavailabilityId) {
       setEditingUnavailabilityId(null);
       setUnavailabilityForm(defaultUnavailabilityForm);
+      setUnavailabilityModalOpen(false);
     }
     await loadVehicleUnavailabilities(selectedVehicleId);
   }
@@ -697,92 +789,440 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
 
   return (
     <section id="scadenze" className="responsive-panel fleet-management-panel" style={{ display: 'grid', gap: 16 }}>
-      <article className="dashboard-card">
-        <div className="panel-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
-          <h2>Gestione Veicoli e Scadenze</h2>
-          <div className="panel-actions" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-            {isAdmin && (
-              <button
-                type="button"
-                className="primary-button compact-button"
-                onClick={syncMissingOccurrences}
-              >
-                <ButtonContent icon={<ResetIcon />}>Sync piani</ButtonContent>
-              </button>
-            )}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
+        <div>
+          <h1 style={{ margin: 0 }}>Gestione Flotta</h1>
+          <p style={{ margin: '4px 0 0' }}>Gestione completa veicolo: anagrafica, scadenze/manutenzioni e piani ricorrenti.</p>
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          {isAdmin && (
             <button
               type="button"
               className="primary-button compact-button"
-              onClick={() => setShowCreateVehicleForm((prev) => !prev)}
+              onClick={syncMissingOccurrences}
             >
-              <ButtonContent icon={showCreateVehicleForm ? <LockIcon /> : <AddIcon />}>{showCreateVehicleForm ? 'Chiudi nuovo veicolo' : 'Nuovo veicolo'}</ButtonContent>
+              <ButtonContent icon={<ResetIcon />}>Sync piani</ButtonContent>
             </button>
+          )}
+          <button
+            type="button"
+            className="primary-button compact-button"
+            onClick={() => { setNewVehicleForm({ plate: '', seats: '', type: 'SEDAN', notes: '' }); setVehicleModal('create'); }}
+          >
+            <ButtonContent icon={<AddIcon />}>Nuovo veicolo</ButtonContent>
+          </button>
+        </div>
+      </div>
+
+      <FleetDeadlinesAlerts />
+
+      {vehicleModal && (
+        <div
+          className="fleet-modal-overlay"
+          onMouseDown={(e) => { if (e.target === e.currentTarget) setVehicleModal(null); }}
+          onKeyDown={(e) => { if (e.key === 'Escape') setVehicleModal(null); }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="vehicle-modal-title"
+          tabIndex={-1}
+          ref={vehicleModalRef}
+        >
+          <div className="fleet-modal">
+            <div className="fleet-modal-header">
+              <h2 id="vehicle-modal-title">{vehicleModal === 'create' ? 'Nuovo veicolo' : 'Modifica veicolo'}</h2>
+              <button type="button" className="fleet-modal-close" onClick={() => setVehicleModal(null)} aria-label="Chiudi">✕</button>
+            </div>
+            {vehicleModal === 'create' ? (
+              <form className="form-grid" onSubmit={createVehicle}>
+                <label>
+                  Targa
+                  <input className="form-input" value={newVehicleForm.plate} onChange={(e) => setNewVehicleForm((p) => ({ ...p, plate: e.target.value }))} required />
+                </label>
+                <label>
+                  Posti
+                  <input className="form-input" type="number" min={1} value={newVehicleForm.seats} onChange={(e) => setNewVehicleForm((p) => ({ ...p, seats: e.target.value }))} required />
+                </label>
+                <label>
+                  Tipo
+                  <select className="form-input" value={newVehicleForm.type} onChange={(e) => setNewVehicleForm((p) => ({ ...p, type: e.target.value as VehicleType }))}>
+                    <option value="SEDAN">Sedan</option>
+                    <option value="VAN">Van</option>
+                    <option value="MINIBUS">Minibus</option>
+                    <option value="SUV">Suv</option>
+                    <option value="OTHER">Altro</option>
+                  </select>
+                </label>
+                <label>
+                  Note
+                  <input className="form-input" value={newVehicleForm.notes} onChange={(e) => setNewVehicleForm((p) => ({ ...p, notes: e.target.value }))} />
+                </label>
+                <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
+                  <button type="submit" className="primary-button compact-button"><ButtonContent icon={<AddIcon />}>Crea veicolo</ButtonContent></button>
+                  <button type="button" className="logout-button compact-button" onClick={() => setNewVehicleForm({ plate: '', seats: '', type: 'SEDAN', notes: '' })}><ButtonContent icon={<ResetIcon />}>Reset</ButtonContent></button>
+                  <button type="button" className="logout-button compact-button" onClick={() => setVehicleModal(null)}><ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent></button>
+                </div>
+              </form>
+            ) : (
+              <form className="form-grid" onSubmit={saveVehicle}>
+                <label>
+                  Targa
+                  <input className="form-input" value={vehicleForm.plate} onChange={(e) => setVehicleForm((p) => ({ ...p, plate: e.target.value }))} required />
+                </label>
+                <label>
+                  Posti
+                  <input className="form-input" type="number" min={1} value={vehicleForm.seats} onChange={(e) => setVehicleForm((p) => ({ ...p, seats: e.target.value }))} required />
+                </label>
+                <label>
+                  Tipo
+                  <select className="form-input" value={vehicleForm.type} onChange={(e) => setVehicleForm((p) => ({ ...p, type: e.target.value as VehicleType }))}>
+                    <option value="SEDAN">Sedan</option>
+                    <option value="VAN">Van</option>
+                    <option value="MINIBUS">Minibus</option>
+                    <option value="SUV">Suv</option>
+                    <option value="OTHER">Altro</option>
+                  </select>
+                </label>
+                <label>
+                  Note
+                  <input className="form-input" value={vehicleForm.notes} onChange={(e) => setVehicleForm((p) => ({ ...p, notes: e.target.value }))} />
+                </label>
+                <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
+                  <button type="submit" className="primary-button compact-button"><ButtonContent icon={<SaveIcon />}>Salva</ButtonContent></button>
+                  <button type="button" className="logout-button compact-button" onClick={() => {
+                    const v = vehicles.find((item) => item.id === selectedVehicleId);
+                    setVehicleForm({ plate: v?.plate ?? '', seats: v ? String(v.seats) : '', type: v?.type ?? 'SEDAN', notes: v?.notes ?? '' });
+                  }}><ButtonContent icon={<ResetIcon />}>Reset</ButtonContent></button>
+                  <button type="button" className="logout-button compact-button" onClick={() => setVehicleModal(null)}><ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent></button>
+                </div>
+              </form>
+            )}
           </div>
         </div>
-        <p>Vista completa: dati veicolo, occorrenze singole, storico e piani ricorrenti.</p>
+      )}
 
-        {showCreateVehicleForm && (
-          <form className="form-grid" onSubmit={createVehicle} style={{ marginBottom: 12 }}>
-            <label>
-              Targa
+      {occurrenceModalOpen && (
+        <div
+          className="fleet-modal-overlay"
+          onMouseDown={(e) => { if (e.target === e.currentTarget) setOccurrenceModalOpen(false); }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="occurrence-modal-title"
+        >
+          <div className="fleet-modal">
+            <div className="fleet-modal-header">
+              <h2 id="occurrence-modal-title">{editingOccurrenceId ? 'Modifica scadenza' : 'Nuova scadenza'}</h2>
+              <button type="button" className="fleet-modal-close" onClick={() => setOccurrenceModalOpen(false)} aria-label="Chiudi">✕</button>
+            </div>
+            <form className="form-grid" onSubmit={saveOccurrence}>
+              <label>
+                Piano (opzionale)
+                <select
+                  className="form-input"
+                  value={occurrenceForm.planId}
+                  onChange={(e) => setOccurrenceForm((p) => ({ ...p, planId: e.target.value ? Number(e.target.value) : '' }))}
+                >
+                  <option value="">Nessun piano</option>
+                  {plans.map((plan) => (
+                    <option key={plan.id} value={plan.id}>{plan.title}</option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Tipo
+                <select className="form-input" value={occurrenceForm.type} onChange={(e) => {
+                  const newType = e.target.value as DeadlineType;
+                  setOccurrenceForm((p) => ({
+                    ...p,
+                    type: newType,
+                    status: sanitizeStatusForType(p.status, newType)
+                  }));
+                }}>
+                  <option value="BOLLO">Bollo</option>
+                  <option value="ASSICURAZIONE">Assicurazione</option>
+                  <option value="REVISIONE">Revisione</option>
+                  <option value="TAGLIANDO">Tagliando</option>
+                  <option value="ALTRO">Altro</option>
+                </select>
+              </label>
+              <label>
+                Titolo
+                <input className="form-input" value={occurrenceForm.title} onChange={(e) => setOccurrenceForm((p) => ({ ...p, title: e.target.value }))} required />
+              </label>
+              <label>
+                Descrizione
+                <input className="form-input" value={occurrenceForm.description} onChange={(e) => setOccurrenceForm((p) => ({ ...p, description: e.target.value }))} />
+              </label>
+              <label>
+                Data scadenza
+                <input className="form-input" type="date" value={occurrenceForm.dueDate} onChange={(e) => setOccurrenceForm((p) => ({ ...p, dueDate: e.target.value }))} required />
+              </label>
+              <label>
+                Stato
+                <select className="form-input" value={occurrenceForm.status} onChange={(e) => setOccurrenceForm((p) => ({ ...p, status: e.target.value as DeadlineStatus }))}>
+                  {allowedStatusesForType(occurrenceForm.type).map((s) => (
+                    <option key={s.value} value={s.value}>{s.label}</option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Costo
+                <input className="form-input" type="number" min={0} step="0.01" value={occurrenceForm.cost} onChange={(e) => setOccurrenceForm((p) => ({ ...p, cost: e.target.value }))} required />
+              </label>
+              <label>
+                Valuta
+                <input className="form-input" maxLength={3} value={occurrenceForm.currency} onChange={(e) => setOccurrenceForm((p) => ({ ...p, currency: e.target.value.toUpperCase() }))} required />
+              </label>
+              <label>
+                Data pagamento
+                <input className="form-input" type="date" value={occurrenceForm.paymentDate} onChange={(e) => setOccurrenceForm((p) => ({ ...p, paymentDate: e.target.value }))} />
+              </label>
+              <label>
+                Data esecuzione
+                <input className="form-input" type="date" value={occurrenceForm.executionDate} onChange={(e) => setOccurrenceForm((p) => ({ ...p, executionDate: e.target.value }))} />
+              </label>
+              <label>
+                Note
+                <input className="form-input" value={occurrenceForm.notes} onChange={(e) => setOccurrenceForm((p) => ({ ...p, notes: e.target.value }))} />
+              </label>
+              <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
+                <button type="submit" className="primary-button compact-button"><ButtonContent icon={<SaveIcon />}>{editingOccurrenceId ? 'Aggiorna scadenza' : 'Crea scadenza'}</ButtonContent></button>
+                <button
+                  type="button"
+                  className="logout-button compact-button"
+                  onClick={() => {
+                    setEditingOccurrenceId(null);
+                    setOccurrenceForm(defaultOccurrenceForm);
+                  }}
+                >
+                  <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
+                </button>
+                <button type="button" className="logout-button compact-button" onClick={() => setOccurrenceModalOpen(false)}><ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent></button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {planModalOpen && (
+        <div
+          className="fleet-modal-overlay"
+          onMouseDown={(e) => { if (e.target === e.currentTarget) setPlanModalOpen(false); }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="plan-modal-title"
+        >
+          <div className="fleet-modal">
+            <div className="fleet-modal-header">
+              <h2 id="plan-modal-title">{editingPlanId ? 'Modifica piano ricorrente' : 'Nuovo piano ricorrente'}</h2>
+              <button type="button" className="fleet-modal-close" onClick={() => setPlanModalOpen(false)} aria-label="Chiudi">✕</button>
+            </div>
+            <form className="form-grid" onSubmit={savePlan}>
+              <label>
+                Tipo
+                <select className="form-input" value={planForm.type} onChange={(e) => setPlanForm((p) => ({ ...p, type: e.target.value as DeadlineType }))}>
+                  <option value="BOLLO">Bollo</option>
+                  <option value="ASSICURAZIONE">Assicurazione</option>
+                  <option value="REVISIONE">Revisione</option>
+                  <option value="TAGLIANDO">Tagliando</option>
+                  <option value="ALTRO">Altro</option>
+                </select>
+              </label>
+              <label>
+                Titolo
+                <input className="form-input" value={planForm.title} onChange={(e) => setPlanForm((p) => ({ ...p, title: e.target.value }))} required />
+              </label>
+              <label>
+                Descrizione
+                <input className="form-input" value={planForm.description} onChange={(e) => setPlanForm((p) => ({ ...p, description: e.target.value }))} />
+              </label>
+              <label>
+                Ricorrenza (mesi)
+                <input className="form-input" type="number" min={1} max={60} value={planForm.recurrenceMonths} onChange={(e) => setPlanForm((p) => ({ ...p, recurrenceMonths: e.target.value }))} required />
+              </label>
+              <label>
+                Prossima scadenza
+                <input className="form-input" type="date" value={planForm.nextDueDate} onChange={(e) => setPlanForm((p) => ({ ...p, nextDueDate: e.target.value }))} required />
+              </label>
+              <label>
+                Costo standard
+                <input className="form-input" type="number" min={0} step="0.01" value={planForm.standardCost} onChange={(e) => setPlanForm((p) => ({ ...p, standardCost: e.target.value }))} required />
+              </label>
+              <label>
+                Valuta
+                <input className="form-input" maxLength={3} value={planForm.currency} onChange={(e) => setPlanForm((p) => ({ ...p, currency: e.target.value.toUpperCase() }))} required />
+              </label>
+              <label>
+                Note
+                <input className="form-input" value={planForm.notes} onChange={(e) => setPlanForm((p) => ({ ...p, notes: e.target.value }))} />
+              </label>
+              <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
+                <button type="submit" className="primary-button compact-button"><ButtonContent icon={<SaveIcon />}>{editingPlanId ? 'Aggiorna piano' : 'Crea piano'}</ButtonContent></button>
+                <button
+                  type="button"
+                  className="logout-button compact-button"
+                  onClick={() => {
+                    setEditingPlanId(null);
+                    setPlanForm(defaultPlanForm);
+                  }}
+                >
+                  <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
+                </button>
+                <button type="button" className="logout-button compact-button" onClick={() => setPlanModalOpen(false)}><ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent></button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {unavailabilityModalOpen && (
+        <div
+          className="fleet-modal-overlay"
+          onMouseDown={(e) => { if (e.target === e.currentTarget) setUnavailabilityModalOpen(false); }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="unavailability-modal-title"
+        >
+          <div className="fleet-modal">
+            <div className="fleet-modal-header">
+              <h2 id="unavailability-modal-title">{editingUnavailabilityId ? 'Modifica manutenzione' : 'Nuova manutenzione'}</h2>
+              <button type="button" className="fleet-modal-close" onClick={() => setUnavailabilityModalOpen(false)} aria-label="Chiudi">✕</button>
+            </div>
+            <form className="form-grid" onSubmit={saveUnavailability}>
+              <label>
+                Dal giorno
+                <input
+                  className="form-input"
+                  type="date"
+                  value={unavailabilityForm.startDate}
+                  onChange={(event) => setUnavailabilityForm((prev) => ({ ...prev, startDate: event.target.value }))}
+                  required
+                />
+              </label>
+              <label>
+                Al giorno
+                <input
+                  className="form-input"
+                  type="date"
+                  value={unavailabilityForm.endDate}
+                  onChange={(event) => setUnavailabilityForm((prev) => ({ ...prev, endDate: event.target.value }))}
+                  required
+                />
+              </label>
+              <label>
+                Motivo guasto/manutenzione
+                <input
+                  className="form-input"
+                  value={unavailabilityForm.reason}
+                  onChange={(event) => setUnavailabilityForm((prev) => ({ ...prev, reason: event.target.value }))}
+                  required
+                />
+              </label>
+              <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
+                <button type="submit" className="primary-button compact-button">
+                  <ButtonContent icon={<SaveIcon />}>{editingUnavailabilityId ? 'Aggiorna manutenzione' : 'Salva manutenzione'}</ButtonContent>
+                </button>
+                <button
+                  type="button"
+                  className="logout-button compact-button"
+                  onClick={() => {
+                    setEditingUnavailabilityId(null);
+                    setUnavailabilityForm(defaultUnavailabilityForm);
+                  }}
+                >
+                  <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
+                </button>
+                <button type="button" className="logout-button compact-button" onClick={() => setUnavailabilityModalOpen(false)}><ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent></button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      <article className="dashboard-card services-filters-card">
+        <button
+          type="button"
+          className="services-filters-label"
+          onClick={() => setVehicleFiltersOpen((prev) => !prev)}
+          aria-expanded={vehicleFiltersOpen}
+          aria-controls="fleet-filters-grid"
+        >
+          <ButtonContent icon={vehicleFiltersOpen ? <LockIcon /> : <FilterIcon />}>
+            {vehicleFiltersOpen ? 'Nascondi filtri' : 'Mostra filtri'}
+          </ButtonContent>
+        </button>
+
+        <div
+          id="fleet-filters-grid"
+          className={`services-filters-panel services-filters-grid ${vehicleFiltersOpen ? '' : 'is-hidden-mobile'}`}
+        >
+          <div className="services-filters-row">
+            <label className="services-filter-group">
+              <span className="services-filter-label">Targa</span>
               <input
-                className="form-input"
-                value={newVehicleForm.plate}
-                onChange={(event) => setNewVehicleForm((prev) => ({ ...prev, plate: event.target.value }))}
-                required
+                className="services-filter-input"
+                value={plateFilter}
+                onChange={(event) => setPlateFilter(event.target.value)}
+                placeholder="Es. RO-TR"
               />
             </label>
-            <label>
-              Posti
+
+            <FilterDropdown
+              className="services-filter-group--type"
+              label="Tipo"
+              value={typeFilter}
+              options={[
+                { value: 'ALL', label: 'Tutti' },
+                { value: 'SEDAN', label: 'Sedan' },
+                { value: 'VAN', label: 'Van' },
+                { value: 'MINIBUS', label: 'Minibus' },
+                { value: 'SUV', label: 'Suv' },
+                { value: 'OTHER', label: 'Altro' },
+              ]}
+              onChange={(v) => setTypeFilter(v as 'ALL' | VehicleType)}
+            />
+
+            <label className="services-filter-group">
+              <span className="services-filter-label">Numero posti</span>
               <input
-                className="form-input"
+                className="services-filter-input"
                 type="number"
                 min={1}
-                value={newVehicleForm.seats}
-                onChange={(event) => setNewVehicleForm((prev) => ({ ...prev, seats: event.target.value }))}
-                required
+                value={seatsFilter}
+                onChange={(event) => setSeatsFilter(event.target.value)}
+                placeholder="Es. 4"
               />
             </label>
-            <label>
-              Tipo
-              <select
-                className="form-input"
-                value={newVehicleForm.type}
-                onChange={(event) => setNewVehicleForm((prev) => ({ ...prev, type: event.target.value as VehicleType }))}
-              >
-                <option value="SEDAN">Sedan</option>
-                <option value="VAN">Van</option>
-                <option value="MINIBUS">Minibus</option>
-                <option value="SUV">Suv</option>
-                <option value="OTHER">Altro</option>
-              </select>
-            </label>
-            <label>
-              Note
-              <input
-                className="form-input"
-                value={newVehicleForm.notes}
-                onChange={(event) => setNewVehicleForm((prev) => ({ ...prev, notes: event.target.value }))}
-              />
-            </label>
-            <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
-              <button type="submit" className="primary-button compact-button"><ButtonContent icon={<AddIcon />}>Crea veicolo</ButtonContent></button>
+          </div>
+
+          {activeVehicleFilterChips.length > 0 && (
+            <div className="services-active-filters-row">
+              <span className="services-active-filters-label">Filtri attivi:</span>
+              <div className="services-active-chips">
+                {activeVehicleFilterChips.map((chip) => (
+                  <span key={chip.key} className="services-active-chip">
+                    <span className="services-active-chip-icon" aria-hidden="true"><FilterIcon /></span>
+                    {chip.label}
+                    <button
+                      type="button"
+                      className="services-active-chip-remove"
+                      onClick={chip.onRemove}
+                      aria-label={`Rimuovi filtro ${chip.label}`}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
               <button
                 type="button"
-                className="logout-button compact-button"
-                onClick={() => setNewVehicleForm({ plate: '', seats: '', type: 'SEDAN', notes: '' })}
+                className="services-reset-link"
+                onClick={resetVehicleFilters}
               >
-                <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
+                Reset filtri
               </button>
             </div>
-          </form>
-        )}
-
-        <p style={{ marginTop: 8 }}>
-          {selectedVehicleId
-            ? `Veicolo selezionato: ${vehicles.find((item) => item.id === selectedVehicleId)?.plate ?? `#${selectedVehicleId}`}`
-            : 'Nessun veicolo selezionato'}
-        </p>
+          )}
+        </div>
       </article>
 
       <article className="dashboard-card">
@@ -790,76 +1230,8 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
               <h3>Lista veicoli</h3>
             </div>
 
-            <div style={{ marginTop: 8, marginBottom: 10 }}>
-              <button
-                type="button"
-                className="logout-button compact-button"
-                onClick={() => setShowFiltersCard((prev) => !prev)}
-              >
-                <ButtonContent icon={showFiltersCard ? <LockIcon /> : <FilterIcon />}>{showFiltersCard ? 'Chiudi filtri' : 'Apri filtri'}</ButtonContent>
-              </button>
-            </div>
-
-            {showFiltersCard && (
-              <div className="dashboard-card" style={{ marginBottom: 10 }}>
-                <div className="form-grid" style={{ display: 'grid', gap: 10 }}>
-                  <label>
-                    Targa
-                    <input
-                      className="form-input"
-                      value={plateFilter}
-                      onChange={(event) => setPlateFilter(event.target.value)}
-                      placeholder="Es. RO-TR"
-                    />
-                  </label>
-
-                  <label>
-                    Tipo
-                    <select
-                      className="form-input"
-                      value={typeFilter}
-                      onChange={(event) => setTypeFilter(event.target.value as 'ALL' | VehicleType)}
-                    >
-                      <option value="ALL">Tutti</option>
-                      <option value="SEDAN">Sedan</option>
-                      <option value="VAN">Van</option>
-                      <option value="MINIBUS">Minibus</option>
-                      <option value="SUV">Suv</option>
-                      <option value="OTHER">Altro</option>
-                    </select>
-                  </label>
-
-                  <label>
-                    Numero posti
-                    <input
-                      className="form-input"
-                      type="number"
-                      min={1}
-                      value={seatsFilter}
-                      onChange={(event) => setSeatsFilter(event.target.value)}
-                      placeholder="Es. 4"
-                    />
-                  </label>
-
-                  <div className="form-actions" style={{ display: 'flex', gap: 8 }}>
-                    <button
-                      type="button"
-                      className="logout-button compact-button"
-                      onClick={() => {
-                        setPlateFilter('');
-                        setTypeFilter('ALL');
-                        setSeatsFilter('');
-                      }}
-                    >
-                      <ButtonContent icon={<ResetIcon />}>Reset filtri</ButtonContent>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            <div className="table-scroll" style={{ overflowX: 'auto', marginTop: 8 }}>
-              <table className="responsive-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <div className="table-scroll services-desktop-table" style={{ overflowX: 'auto', marginTop: 8 }}>
+              <table className="responsive-table services-table services-table-modern" style={{ width: '100%', minWidth: 860, borderCollapse: 'collapse' }}>
                 <thead>
                   <tr>
                     <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Targa</th>
@@ -880,7 +1252,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                     filteredVehicles.map((vehicle) => (
                       <tr
                         key={vehicle.id}
-                        style={selectedVehicleId === vehicle.id ? { background: '#eaf1f9' } : undefined}
+                        className={`services-table-row ${selectedVehicleId === vehicle.id ? 'is-selected' : ''}`}
                         aria-current={selectedVehicleId === vehicle.id ? 'true' : undefined}
                       >
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{vehicle.plate}</td>
@@ -909,51 +1281,51 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
               </table>
             </div>
 
-            {showVehicleForm && selectedVehicleId && (
-              <form className="form-grid" onSubmit={saveVehicle} style={{ marginTop: 10 }}>
-                <label>
-                  Targa
-                  <input className="form-input" value={vehicleForm.plate} onChange={(e) => setVehicleForm((p) => ({ ...p, plate: e.target.value }))} required />
-                </label>
-                <label>
-                  Posti
-                  <input className="form-input" type="number" min={1} value={vehicleForm.seats} onChange={(e) => setVehicleForm((p) => ({ ...p, seats: e.target.value }))} required />
-                </label>
-                <label>
-                  Tipo
-                  <select className="form-input" value={vehicleForm.type} onChange={(e) => setVehicleForm((p) => ({ ...p, type: e.target.value as VehicleType }))}>
-                    <option value="SEDAN">Sedan</option>
-                    <option value="VAN">Van</option>
-                    <option value="MINIBUS">Minibus</option>
-                    <option value="SUV">Suv</option>
-                    <option value="OTHER">Altro</option>
-                  </select>
-                </label>
-                <label>
-                  Note
-                  <input className="form-input" value={vehicleForm.notes} onChange={(e) => setVehicleForm((p) => ({ ...p, notes: e.target.value }))} />
-                </label>
-                <div className="form-actions sticky-mobile fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
-                  <button type="submit" className="primary-button compact-button"><ButtonContent icon={<SaveIcon />}>Salva dati veicolo</ButtonContent></button>
-                  <button
-                    type="button"
-                    className="logout-button compact-button"
-                    onClick={() => {
-                      const selectedVehicle = vehicles.find((item) => item.id === selectedVehicleId);
-                      setVehicleForm({
-                        plate: selectedVehicle?.plate ?? '',
-                        seats: selectedVehicle ? String(selectedVehicle.seats) : '',
-                        type: selectedVehicle?.type ?? 'SEDAN',
-                        notes: selectedVehicle?.notes ?? ''
-                      });
-                    }}
+            <div className="services-mobile-list" style={{ marginTop: 8 }}>
+              {filteredVehicles.length === 0 ? (
+                <article className="service-mobile-card">
+                  <div className="service-mobile-meta">
+                    <span>{vehicles.length === 0 ? 'Nessun veicolo presente.' : 'Nessun veicolo corrisponde ai filtri.'}</span>
+                  </div>
+                </article>
+              ) : (
+                filteredVehicles.map((vehicle) => (
+                  <article
+                    key={vehicle.id}
+                    className={`service-mobile-card ${selectedVehicleId === vehicle.id ? 'is-selected' : ''}`}
                   >
-                    <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
-                  </button>
-                  <button type="button" className="logout-button" onClick={() => setShowVehicleForm(false)}><ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent></button>
-                </div>
-              </form>
-            )}
+                    <div className="service-mobile-card-top">
+                      <div className="service-mobile-badges">
+                        <span className="service-chip service-chip-type">{vehicleTypeLabel(vehicle.type)}</span>
+                      </div>
+                      <strong className="service-mobile-price">{vehicle.seats} posti</strong>
+                    </div>
+
+                    <div className="service-mobile-meta">
+                      <span>Targa: {vehicle.plate}</span>
+                    </div>
+                    <div className="service-mobile-meta">
+                      <span>Note: {vehicle.notes ?? '-'}</span>
+                    </div>
+
+                    <div className="service-mobile-actions">
+                      <button type="button" className="primary-button compact-button" onClick={() => editVehicle(vehicle)}>
+                        <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
+                      </button>
+                      <button
+                        type="button"
+                        className="logout-button compact-button"
+                        onClick={() => selectVehicle(vehicle.id)}
+                        disabled={selectedVehicleId === vehicle.id}
+                      >
+                        <ButtonContent icon={<SelectIcon />}>{selectedVehicleId === vehicle.id ? 'Selezionato' : 'Seleziona'}</ButtonContent>
+                      </button>
+                    </div>
+                  </article>
+                ))
+              )}
+            </div>
+
       </article>
 
       {!selectedVehicleId ? (
@@ -970,106 +1342,14 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
               <button
                 type="button"
                 className="primary-button compact-button"
-                onClick={() => {
-                  setShowOccurrenceForm((prev) => !prev);
-                  setEditingOccurrenceId(null);
-                  setOccurrenceForm(defaultOccurrenceForm);
-                }}
+                onClick={openOccurrenceCreateModal}
               >
-                <ButtonContent icon={showOccurrenceForm ? <LockIcon /> : <AddIcon />}>{showOccurrenceForm ? 'Chiudi' : 'Aggiungi scadenza'}</ButtonContent>
+                <ButtonContent icon={<AddIcon />}>Aggiungi scadenza</ButtonContent>
               </button>
             </div>
 
-            {showOccurrenceForm && (
-              <form className="form-grid" onSubmit={saveOccurrence}>
-                <label>
-                  Piano (opzionale)
-                  <select
-                    className="form-input"
-                    value={occurrenceForm.planId}
-                    onChange={(e) => setOccurrenceForm((p) => ({ ...p, planId: e.target.value ? Number(e.target.value) : '' }))}
-                  >
-                    <option value="">Nessun piano</option>
-                    {plans.map((plan) => (
-                      <option key={plan.id} value={plan.id}>{plan.title}</option>
-                    ))}
-                  </select>
-                </label>
-                <label>
-                  Tipo
-                  <select className="form-input" value={occurrenceForm.type} onChange={(e) => {
-                    const newType = e.target.value as DeadlineType;
-                    setOccurrenceForm((p) => ({
-                      ...p,
-                      type: newType,
-                      status: sanitizeStatusForType(p.status, newType)
-                    }));
-                  }}>
-                    <option value="BOLLO">Bollo</option>
-                    <option value="ASSICURAZIONE">Assicurazione</option>
-                    <option value="REVISIONE">Revisione</option>
-                    <option value="TAGLIANDO">Tagliando</option>
-                    <option value="ALTRO">Altro</option>
-                  </select>
-                </label>
-                <label>
-                  Titolo
-                  <input className="form-input" value={occurrenceForm.title} onChange={(e) => setOccurrenceForm((p) => ({ ...p, title: e.target.value }))} required />
-                </label>
-                <label>
-                  Descrizione
-                  <input className="form-input" value={occurrenceForm.description} onChange={(e) => setOccurrenceForm((p) => ({ ...p, description: e.target.value }))} />
-                </label>
-                <label>
-                  Data scadenza
-                  <input className="form-input" type="date" value={occurrenceForm.dueDate} onChange={(e) => setOccurrenceForm((p) => ({ ...p, dueDate: e.target.value }))} required />
-                </label>
-                <label>
-                  Stato
-                  <select className="form-input" value={occurrenceForm.status} onChange={(e) => setOccurrenceForm((p) => ({ ...p, status: e.target.value as DeadlineStatus }))}>
-                    {allowedStatusesForType(occurrenceForm.type).map((s) => (
-                      <option key={s.value} value={s.value}>{s.label}</option>
-                    ))}
-                  </select>
-                </label>
-                <label>
-                  Costo
-                  <input className="form-input" type="number" min={0} step="0.01" value={occurrenceForm.cost} onChange={(e) => setOccurrenceForm((p) => ({ ...p, cost: e.target.value }))} required />
-                </label>
-                <label>
-                  Valuta
-                  <input className="form-input" maxLength={3} value={occurrenceForm.currency} onChange={(e) => setOccurrenceForm((p) => ({ ...p, currency: e.target.value.toUpperCase() }))} required />
-                </label>
-                <label>
-                  Data pagamento
-                  <input className="form-input" type="date" value={occurrenceForm.paymentDate} onChange={(e) => setOccurrenceForm((p) => ({ ...p, paymentDate: e.target.value }))} />
-                </label>
-                <label>
-                  Data esecuzione
-                  <input className="form-input" type="date" value={occurrenceForm.executionDate} onChange={(e) => setOccurrenceForm((p) => ({ ...p, executionDate: e.target.value }))} />
-                </label>
-                <label>
-                  Note
-                  <input className="form-input" value={occurrenceForm.notes} onChange={(e) => setOccurrenceForm((p) => ({ ...p, notes: e.target.value }))} />
-                </label>
-                <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
-                  <button type="submit" className="primary-button compact-button"><ButtonContent icon={<SaveIcon />}>{editingOccurrenceId ? 'Aggiorna scadenza' : 'Crea scadenza'}</ButtonContent></button>
-                  <button
-                    type="button"
-                    className="logout-button compact-button"
-                    onClick={() => {
-                      setEditingOccurrenceId(null);
-                      setOccurrenceForm(defaultOccurrenceForm);
-                    }}
-                  >
-                    <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
-                  </button>
-                </div>
-              </form>
-            )}
-
-            <div className="table-scroll" style={{ overflowX: 'auto', marginTop: 8 }}>
-              <table className="responsive-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <div className="table-scroll services-desktop-table" style={{ overflowX: 'auto', marginTop: 8 }}>
+              <table className="responsive-table services-table services-table-modern" style={{ width: '100%', minWidth: 980, borderCollapse: 'collapse' }}>
                 <thead>
                   <tr>
                     <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Tipo</th>
@@ -1082,7 +1362,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                 </thead>
                 <tbody>
                   {occurrences.map((item) => (
-                    <tr key={item.id}>
+                    <tr key={item.id} className="services-table-row">
                       {(() => {
                         const overdue = isOverdueStatus(item.status);
                         const dueSoon = !overdue && isDueSoonStatus(item.status, item.dueDate);
@@ -1101,23 +1381,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{item.cost} {item.currency}</td>
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>
                           <div className="table-actions" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                            <button type="button" className="primary-button compact-button" onClick={() => {
-                              setEditingOccurrenceId(item.id);
-                              setShowOccurrenceForm(true);
-                              setOccurrenceForm({
-                                planId: item.planId ?? '',
-                                type: item.type,
-                                title: item.title,
-                                description: item.description ?? '',
-                                dueDate: item.dueDate,
-                                status: item.status,
-                                cost: String(item.cost),
-                                currency: item.currency,
-                                notes: item.notes ?? '',
-                                paymentDate: item.paymentDate ?? '',
-                                executionDate: item.executionDate ?? ''
-                              });
-                            }}><ButtonContent icon={<EditIcon />}>Modifica</ButtonContent></button>
+                            <button type="button" className="primary-button compact-button" onClick={() => openOccurrenceEditModal(item)}><ButtonContent icon={<EditIcon />}>Modifica</ButtonContent></button>
 
                             {(item.type === 'BOLLO' || item.type === 'ASSICURAZIONE') ? (
                               <button
@@ -1156,76 +1420,84 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                 </tbody>
               </table>
             </div>
+
+            <div className="services-mobile-list" style={{ marginTop: 8 }}>
+              {occurrences.length === 0 ? (
+                <article className="service-mobile-card">
+                  <div className="service-mobile-meta">
+                    <span>Nessuna scadenza registrata.</span>
+                  </div>
+                </article>
+              ) : (
+                occurrences.map((item) => {
+                  const overdue = isOverdueStatus(item.status);
+                  const dueSoon = !overdue && isDueSoonStatus(item.status, item.dueDate);
+                  const highlightClass = overdue ? 'error-text' : dueSoon ? 'warning-text' : undefined;
+
+                  return (
+                    <article key={item.id} className="service-mobile-card">
+                      <div className="service-mobile-card-top">
+                        <div className="service-mobile-badges">
+                          <span className="service-chip service-chip-type">{typeLabel(item.type)}</span>
+                          <span className="service-chip service-chip-type-neutral">{statusLabel(item.status)}</span>
+                        </div>
+                        <strong className="service-mobile-price">{item.cost} {item.currency}</strong>
+                      </div>
+
+                      <div className="service-mobile-meta">
+                        <span>{item.title}</span>
+                      </div>
+                      <div className="service-mobile-meta">
+                        <span className={highlightClass}>Scadenza: {item.dueDate}</span>
+                      </div>
+
+                      <div className="service-mobile-actions">
+                        <button type="button" className="primary-button compact-button" onClick={() => openOccurrenceEditModal(item)}><ButtonContent icon={<EditIcon />}>Modifica</ButtonContent></button>
+
+                        {(item.type === 'BOLLO' || item.type === 'ASSICURAZIONE') ? (
+                          <button
+                            type="button"
+                            className="logout-button compact-button"
+                            onClick={() => quickOccurrenceAction(item.id, 'paid')}
+                            disabled={!canMarkOccurrenceAsPaid(item) || occurrenceActionLoadingId === item.id}
+                          >
+                            <ButtonContent icon={<SaveIcon />}>Segna pagata</ButtonContent>
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            className="logout-button compact-button"
+                            onClick={() => quickOccurrenceAction(item.id, 'completed')}
+                            disabled={!canMarkOccurrenceAsCompleted(item) || occurrenceActionLoadingId === item.id}
+                          >
+                            <ButtonContent icon={<SaveIcon />}>Segna eseguita</ButtonContent>
+                          </button>
+                        )}
+
+                        <button
+                          type="button"
+                          className="logout-button compact-button"
+                          onClick={() => quickOccurrenceAction(item.id, 'cancel')}
+                          disabled={!canCancelOccurrence(item) || occurrenceActionLoadingId === item.id}
+                        >
+                          <ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent>
+                        </button>
+                      </div>
+                    </article>
+                  );
+                })
+              )}
+            </div>
           </article>
 
           <article className="dashboard-card">
             <div className="panel-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
               <h3>Piani ricorrenti</h3>
-              <button type="button" className="primary-button compact-button" onClick={() => {
-                setShowPlanForm((prev) => !prev);
-                setEditingPlanId(null);
-                setPlanForm(defaultPlanForm);
-              }}><ButtonContent icon={showPlanForm ? <LockIcon /> : <AddIcon />}>{showPlanForm ? 'Chiudi' : 'Aggiungi piano ricorrente'}</ButtonContent></button>
+              <button type="button" className="primary-button compact-button" onClick={openPlanCreateModal}><ButtonContent icon={<AddIcon />}>Aggiungi piano ricorrente</ButtonContent></button>
             </div>
 
-            {showPlanForm && (
-              <form className="form-grid" onSubmit={savePlan}>
-                <label>
-                  Tipo
-                  <select className="form-input" value={planForm.type} onChange={(e) => setPlanForm((p) => ({ ...p, type: e.target.value as DeadlineType }))}>
-                    <option value="BOLLO">Bollo</option>
-                    <option value="ASSICURAZIONE">Assicurazione</option>
-                    <option value="REVISIONE">Revisione</option>
-                    <option value="TAGLIANDO">Tagliando</option>
-                    <option value="ALTRO">Altro</option>
-                  </select>
-                </label>
-                <label>
-                  Titolo
-                  <input className="form-input" value={planForm.title} onChange={(e) => setPlanForm((p) => ({ ...p, title: e.target.value }))} required />
-                </label>
-                <label>
-                  Descrizione
-                  <input className="form-input" value={planForm.description} onChange={(e) => setPlanForm((p) => ({ ...p, description: e.target.value }))} />
-                </label>
-                <label>
-                  Ricorrenza (mesi)
-                  <input className="form-input" type="number" min={1} max={60} value={planForm.recurrenceMonths} onChange={(e) => setPlanForm((p) => ({ ...p, recurrenceMonths: e.target.value }))} required />
-                </label>
-                <label>
-                  Prossima scadenza
-                  <input className="form-input" type="date" value={planForm.nextDueDate} onChange={(e) => setPlanForm((p) => ({ ...p, nextDueDate: e.target.value }))} required />
-                </label>
-                <label>
-                  Costo standard
-                  <input className="form-input" type="number" min={0} step="0.01" value={planForm.standardCost} onChange={(e) => setPlanForm((p) => ({ ...p, standardCost: e.target.value }))} required />
-                </label>
-                <label>
-                  Valuta
-                  <input className="form-input" maxLength={3} value={planForm.currency} onChange={(e) => setPlanForm((p) => ({ ...p, currency: e.target.value.toUpperCase() }))} required />
-                </label>
-                <label>
-                  Note
-                  <input className="form-input" value={planForm.notes} onChange={(e) => setPlanForm((p) => ({ ...p, notes: e.target.value }))} />
-                </label>
-                <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
-                  <button type="submit" className="primary-button compact-button"><ButtonContent icon={<SaveIcon />}>{editingPlanId ? 'Aggiorna piano' : 'Crea piano'}</ButtonContent></button>
-                  <button
-                    type="button"
-                    className="logout-button compact-button"
-                    onClick={() => {
-                      setEditingPlanId(null);
-                      setPlanForm(defaultPlanForm);
-                    }}
-                  >
-                    <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
-                  </button>
-                </div>
-              </form>
-            )}
-
-            <div className="table-scroll" style={{ overflowX: 'auto', marginTop: 8 }}>
-              <table className="responsive-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <div className="table-scroll services-desktop-table" style={{ overflowX: 'auto', marginTop: 8 }}>
+              <table className="responsive-table services-table services-table-modern" style={{ width: '100%', minWidth: 980, borderCollapse: 'collapse' }}>
                 <thead>
                   <tr>
                     <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Tipo</th>
@@ -1246,7 +1518,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                     </tr>
                   ) : (
                     plans.map((item) => (
-                      <tr key={item.id}>
+                      <tr key={item.id} className="services-table-row">
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{typeLabel(item.type)}</td>
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{item.title}</td>
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{item.recurrenceMonths} mesi</td>
@@ -1255,20 +1527,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{item.active ? 'Attivo' : 'Inattivo'}</td>
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>
                           <div className="table-actions" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                            <button type="button" className="primary-button compact-button" onClick={() => {
-                              setEditingPlanId(item.id);
-                              setShowPlanForm(true);
-                              setPlanForm({
-                                type: item.type,
-                                title: item.title,
-                                description: item.description ?? '',
-                                recurrenceMonths: String(item.recurrenceMonths),
-                                nextDueDate: item.nextDueDate,
-                                standardCost: String(item.standardCost),
-                                currency: item.currency,
-                                notes: item.notes ?? ''
-                              });
-                            }}><ButtonContent icon={<EditIcon />}>Modifica</ButtonContent></button>
+                            <button type="button" className="primary-button compact-button" onClick={() => openPlanEditModal(item)}><ButtonContent icon={<EditIcon />}>Modifica</ButtonContent></button>
                             <button
                               type="button"
                               className="logout-button"
@@ -1284,6 +1543,47 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                 </tbody>
               </table>
             </div>
+
+            <div className="services-mobile-list" style={{ marginTop: 8 }}>
+              {plans.length === 0 ? (
+                <article className="service-mobile-card">
+                  <div className="service-mobile-meta">
+                    <span>Nessun piano registrato.</span>
+                  </div>
+                </article>
+              ) : (
+                plans.map((item) => (
+                  <article key={item.id} className="service-mobile-card">
+                    <div className="service-mobile-card-top">
+                      <div className="service-mobile-badges">
+                        <span className="service-chip service-chip-type">{typeLabel(item.type)}</span>
+                        <span className="service-chip service-chip-type-neutral">{item.active ? 'Attivo' : 'Inattivo'}</span>
+                      </div>
+                      <strong className="service-mobile-price">{item.standardCost} {item.currency}</strong>
+                    </div>
+
+                    <div className="service-mobile-meta">
+                      <span>{item.title}</span>
+                      <span>{item.recurrenceMonths} mesi</span>
+                    </div>
+                    <div className="service-mobile-meta">
+                      <span>Prossima scadenza: {item.nextDueDate}</span>
+                    </div>
+
+                    <div className="service-mobile-actions">
+                      <button type="button" className="primary-button compact-button" onClick={() => openPlanEditModal(item)}><ButtonContent icon={<EditIcon />}>Modifica</ButtonContent></button>
+                      <button
+                        type="button"
+                        className="logout-button compact-button"
+                        onClick={() => togglePlan(item.id, item.active)}
+                      >
+                        <ButtonContent icon={<ResetIcon />}>{item.active ? 'Disattiva piano' : 'Riattiva piano'}</ButtonContent>
+                      </button>
+                    </div>
+                  </article>
+                ))
+              )}
+            </div>
           </article>
 
           <article className="dashboard-card">
@@ -1292,67 +1592,14 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
               <button
                 type="button"
                 className="primary-button compact-button"
-                onClick={() => {
-                  setShowUnavailabilityForm((prev) => !prev);
-                  setEditingUnavailabilityId(null);
-                  setUnavailabilityForm(defaultUnavailabilityForm);
-                }}
+                onClick={openUnavailabilityCreateModal}
               >
-                <ButtonContent icon={showUnavailabilityForm ? <LockIcon /> : <AddIcon />}>{showUnavailabilityForm ? 'Chiudi' : 'Nuova manutenzione'}</ButtonContent>
+                <ButtonContent icon={<AddIcon />}>Nuova manutenzione</ButtonContent>
               </button>
             </div>
 
-            {showUnavailabilityForm && (
-              <form className="form-grid" onSubmit={saveUnavailability}>
-                <label>
-                  Dal giorno
-                  <input
-                    className="form-input"
-                    type="date"
-                    value={unavailabilityForm.startDate}
-                    onChange={(event) => setUnavailabilityForm((prev) => ({ ...prev, startDate: event.target.value }))}
-                    required
-                  />
-                </label>
-                <label>
-                  Al giorno
-                  <input
-                    className="form-input"
-                    type="date"
-                    value={unavailabilityForm.endDate}
-                    onChange={(event) => setUnavailabilityForm((prev) => ({ ...prev, endDate: event.target.value }))}
-                    required
-                  />
-                </label>
-                <label>
-                  Motivo guasto/manutenzione
-                  <input
-                    className="form-input"
-                    value={unavailabilityForm.reason}
-                    onChange={(event) => setUnavailabilityForm((prev) => ({ ...prev, reason: event.target.value }))}
-                    required
-                  />
-                </label>
-                <div className="form-actions fleet-form-actions" style={{ display: 'flex', gap: 8 }}>
-                  <button type="submit" className="primary-button compact-button">
-                    <ButtonContent icon={<SaveIcon />}>{editingUnavailabilityId ? 'Aggiorna manutenzione' : 'Salva manutenzione'}</ButtonContent>
-                  </button>
-                  <button
-                    type="button"
-                    className="logout-button compact-button"
-                    onClick={() => {
-                      setEditingUnavailabilityId(null);
-                      setUnavailabilityForm(defaultUnavailabilityForm);
-                    }}
-                  >
-                    <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
-                  </button>
-                </div>
-              </form>
-            )}
-
-            <div className="table-scroll" style={{ overflowX: 'auto', marginTop: 8 }}>
-              <table className="responsive-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <div className="table-scroll services-desktop-table" style={{ overflowX: 'auto', marginTop: 8 }}>
+              <table className="responsive-table services-table services-table-modern" style={{ width: '100%', minWidth: 760, borderCollapse: 'collapse' }}>
                 <thead>
                   <tr>
                     <th style={{ textAlign: 'left', padding: '0 10px 8px 0' }}>Inizio</th>
@@ -1370,7 +1617,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                     </tr>
                   ) : (
                     unavailabilities.map((item) => (
-                      <tr key={item.id}>
+                      <tr key={item.id} className="services-table-row">
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{item.startDate}</td>
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{item.endDate}</td>
                         <td style={{ padding: '8px 10px 8px 0', borderBottom: '1px solid #eaf1f9' }}>{item.reason}</td>
@@ -1379,15 +1626,7 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                             <button
                               type="button"
                               className="primary-button compact-button"
-                              onClick={() => {
-                                setEditingUnavailabilityId(item.id);
-                                setShowUnavailabilityForm(true);
-                                setUnavailabilityForm({
-                                  startDate: item.startDate,
-                                  endDate: item.endDate,
-                                  reason: item.reason
-                                });
-                              }}
+                              onClick={() => openUnavailabilityEditModal(item)}
                             >
                               <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
                             </button>
@@ -1405,6 +1644,52 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
                   )}
                 </tbody>
               </table>
+            </div>
+
+            <div className="services-mobile-list" style={{ marginTop: 8 }}>
+              {unavailabilities.length === 0 ? (
+                <article className="service-mobile-card">
+                  <div className="service-mobile-meta">
+                    <span>Nessuna manutenzione registrata.</span>
+                  </div>
+                </article>
+              ) : (
+                unavailabilities.map((item) => (
+                  <article key={item.id} className="service-mobile-card">
+                    <div className="service-mobile-card-top">
+                      <div className="service-mobile-badges">
+                        <span className="service-chip service-chip-type">Manutenzione</span>
+                      </div>
+                      <strong className="service-mobile-price">{item.startDate}</strong>
+                    </div>
+
+                    <div className="service-mobile-meta">
+                      <span>Dal: {item.startDate}</span>
+                      <span>Al: {item.endDate}</span>
+                    </div>
+                    <div className="service-mobile-meta">
+                      <span>{item.reason}</span>
+                    </div>
+
+                    <div className="service-mobile-actions">
+                      <button
+                        type="button"
+                        className="primary-button compact-button"
+                        onClick={() => openUnavailabilityEditModal(item)}
+                      >
+                        <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
+                      </button>
+                      <button
+                        type="button"
+                        className="logout-button compact-button"
+                        onClick={() => deleteUnavailability(item.id)}
+                      >
+                        <ButtonContent icon={<DeleteIcon />}>Elimina</ButtonContent>
+                      </button>
+                    </div>
+                  </article>
+                ))
+              )}
             </div>
           </article>
         </>

--- a/frontend/components/fleet-vehicle-management.tsx
+++ b/frontend/components/fleet-vehicle-management.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useState } from 'react';
 import { AddIcon, ButtonContent, CancelIcon, DeleteIcon, EditIcon, FilterIcon, LockIcon, ResetIcon, SaveIcon, SelectIcon } from './action-icons';
+import { StatusNotice } from './status-notice';
 
 type VehicleType = 'SEDAN' | 'VAN' | 'MINIBUS' | 'SUV' | 'OTHER';
 type DeadlineType = 'BOLLO' | 'ASSICURAZIONE' | 'REVISIONE' | 'TAGLIANDO' | 'ALTRO';
@@ -1409,8 +1410,8 @@ export function FleetVehicleManagement({ userRole = 'UNKNOWN', initialVehicleId 
         </>
       )}
 
-      {error && <article className="dashboard-card"><p className="error-text">{error}</p></article>}
-      {success && <article className="dashboard-card"><p className="success-text">{success}</p></article>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
+      {success && <StatusNotice tone="success">{success}</StatusNotice>}
     </section>
   );
 }

--- a/frontend/components/fleet-vehicles-panel.tsx
+++ b/frontend/components/fleet-vehicles-panel.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useState } from 'react';
 import { AddIcon, ButtonContent, CancelIcon, DeleteIcon, EditIcon, LockIcon, SaveIcon } from './action-icons';
+import { StatusNotice } from './status-notice';
 
 type VehicleType = 'SEDAN' | 'VAN' | 'MINIBUS' | 'SUV' | 'OTHER';
 type DeadlineType = 'BOLLO' | 'ASSICURAZIONE' | 'REVISIONE' | 'TAGLIANDO' | 'ALTRO';
@@ -471,8 +472,8 @@ export function FleetVehiclesPanel() {
           </form>
         )}
 
-        {error && <p className="error-text" style={{ marginTop: 8 }}>{error}</p>}
-        {success && <p className="success-text" style={{ marginTop: 8 }}>{success}</p>}
+        {error && <StatusNotice tone="error" className="fleet-inline-notice">{error}</StatusNotice>}
+        {success && <StatusNotice tone="success" className="fleet-inline-notice">{success}</StatusNotice>}
       </article>
 
       <article className="dashboard-card">

--- a/frontend/components/forgot-password-form.tsx
+++ b/frontend/components/forgot-password-form.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useState } from 'react';
 import { ButtonContent, LoginIcon } from './action-icons';
+import { StatusNotice } from './status-notice';
 
 export function ForgotPasswordForm() {
   const [email, setEmail] = useState('admin@rideops.local');
@@ -47,8 +48,8 @@ export function ForgotPasswordForm() {
       <button type="submit" disabled={loading} className="primary-button">
         <ButtonContent icon={<LoginIcon />}>{loading ? 'Invio...' : 'Invia link reset'}</ButtonContent>
       </button>
-      {message && <p className="success-text">{message}</p>}
-      {error && <p className="error-text">{error}</p>}
+      {message && <StatusNotice tone="success">{message}</StatusNotice>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
       <p>
         In MVP il link di reset è inviato su outbox/log backend.
       </p>

--- a/frontend/components/gestionale-drivers-panel.tsx
+++ b/frontend/components/gestionale-drivers-panel.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { AddIcon, ButtonContent, CancelIcon, DeleteIcon, EditIcon, FilterIcon, ResetIcon, SaveIcon, SearchIcon, SelectIcon } from './action-icons';
 import { PasswordInput } from './password-input';
+import { StatusNotice } from './status-notice';
 
 type LicenseType = 'AM' | 'A1' | 'A2' | 'A' | 'B' | 'BE' | 'C' | 'CE' | 'D' | 'DE' | 'CQC';
 
@@ -1034,8 +1035,8 @@ export function GestionaleDriversPanel() {
         </div>
       )}
 
-      {error && <p className="error-text">{error}</p>}
-      {success && <p className="success-text">{success}</p>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
+      {success && <StatusNotice tone="success">{success}</StatusNotice>}
     </section>
   );
 }

--- a/frontend/components/gestionale-drivers-panel.tsx
+++ b/frontend/components/gestionale-drivers-panel.tsx
@@ -204,6 +204,8 @@ export function GestionaleDriversPanel() {
   const [driverQuery, setDriverQuery] = useState('');
   const [selectedDriverId, setSelectedDriverId] = useState<number | null>(null);
   const [editingDriverId, setEditingDriverId] = useState<number | null>(null);
+  const [rowMenuDriverId, setRowMenuDriverId] = useState<number | null>(null);
+  const [rowMenuDriverAnchor, setRowMenuDriverAnchor] = useState<{ top: number; right: number } | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [newButtonPortalTarget, setNewButtonPortalTarget] = useState<HTMLElement | null>(null);
   const [form, setForm] = useState<DriverFormState>(defaultForm);
@@ -279,6 +281,30 @@ export function GestionaleDriversPanel() {
 
   useEffect(() => {
     setNewButtonPortalTarget(document.getElementById('gestionale-driver-new-button-portal'));
+  }, []);
+
+  useEffect(() => {
+    function onDocumentClick(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (target && target.closest('.services-row-menu')) {
+        return;
+      }
+      setRowMenuDriverId(null);
+    }
+
+    function onDocumentKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setRowMenuDriverId(null);
+      }
+    }
+
+    document.addEventListener('click', onDocumentClick);
+    document.addEventListener('keydown', onDocumentKeyDown);
+
+    return () => {
+      document.removeEventListener('click', onDocumentClick);
+      document.removeEventListener('keydown', onDocumentKeyDown);
+    };
   }, []);
 
   async function onToggleIncludeDeleted(checked: boolean) {
@@ -499,88 +525,90 @@ export function GestionaleDriversPanel() {
         </button>
       </div>
 
-      <section className="gestionale-driver-kpi-grid" aria-label="Statistiche driver">
-        <article className="dashboard-card gestionale-driver-kpi-card">
-          <div className="gestionale-driver-kpi-top">
-            <div className="gestionale-driver-kpi-icon gestionale-driver-kpi-icon--active" aria-hidden="true"><DriverActiveIcon /></div>
-            <p className="gestionale-driver-kpi-label">
-              <span className="gestionale-driver-kpi-label-desktop">Driver attivi</span>
-              <span className="gestionale-driver-kpi-label-mobile">Attivi</span>
-            </p>
-          </div>
-          <p className="gestionale-driver-kpi-value">{stats.active}</p>
-        </article>
+      <div className="gestionale-driver-informative-stack">
+        <section className="gestionale-driver-kpi-grid" aria-label="Statistiche driver">
+          <article className="dashboard-card gestionale-driver-kpi-card">
+            <div className="gestionale-driver-kpi-top">
+              <div className="gestionale-driver-kpi-icon gestionale-driver-kpi-icon--active" aria-hidden="true"><DriverActiveIcon /></div>
+              <p className="gestionale-driver-kpi-label">
+                <span className="gestionale-driver-kpi-label-desktop">Driver attivi</span>
+                <span className="gestionale-driver-kpi-label-mobile">Attivi</span>
+              </p>
+            </div>
+            <p className="gestionale-driver-kpi-value">{stats.active}</p>
+          </article>
 
-        <article className="dashboard-card gestionale-driver-kpi-card">
-          <div className="gestionale-driver-kpi-top">
-            <div className="gestionale-driver-kpi-icon gestionale-driver-kpi-icon--expiry" aria-hidden="true"><DriverExpiryIcon /></div>
-            <p className="gestionale-driver-kpi-label">
-              <span className="gestionale-driver-kpi-label-desktop">Patenti in scadenza (90gg)</span>
-              <span className="gestionale-driver-kpi-label-mobile">Scadenza</span>
-            </p>
-          </div>
-          <p className="gestionale-driver-kpi-value">{stats.expiringIn90Days}</p>
-        </article>
+          <article className="dashboard-card gestionale-driver-kpi-card">
+            <div className="gestionale-driver-kpi-top">
+              <div className="gestionale-driver-kpi-icon gestionale-driver-kpi-icon--expiry" aria-hidden="true"><DriverExpiryIcon /></div>
+              <p className="gestionale-driver-kpi-label">
+                <span className="gestionale-driver-kpi-label-desktop">Patenti in scadenza (90gg)</span>
+                <span className="gestionale-driver-kpi-label-mobile">Scadenza</span>
+              </p>
+            </div>
+            <p className="gestionale-driver-kpi-value">{stats.expiringIn90Days}</p>
+          </article>
 
-        <article className="dashboard-card gestionale-driver-kpi-card">
-          <div className="gestionale-driver-kpi-top">
-            <div className="gestionale-driver-kpi-icon gestionale-driver-kpi-icon--disabled" aria-hidden="true"><DriverDisabledIcon /></div>
-            <p className="gestionale-driver-kpi-label">
-              <span className="gestionale-driver-kpi-label-desktop">Disattivati</span>
-              <span className="gestionale-driver-kpi-label-mobile">Disatt.</span>
-            </p>
-          </div>
-          <p className="gestionale-driver-kpi-value">{stats.disabled}</p>
-        </article>
-      </section>
+          <article className="dashboard-card gestionale-driver-kpi-card">
+            <div className="gestionale-driver-kpi-top">
+              <div className="gestionale-driver-kpi-icon gestionale-driver-kpi-icon--disabled" aria-hidden="true"><DriverDisabledIcon /></div>
+              <p className="gestionale-driver-kpi-label">
+                <span className="gestionale-driver-kpi-label-desktop">Disattivati</span>
+                <span className="gestionale-driver-kpi-label-mobile">Disatt.</span>
+              </p>
+            </div>
+            <p className="gestionale-driver-kpi-value">{stats.disabled}</p>
+          </article>
+        </section>
 
-      {selectedDriver && (
-        <article className="dashboard-card gestionale-driver-selected-card">
-          <div className="gestionale-driver-selected-header">
-            <div className="gestionale-driver-selected-title-wrap">
-              <span className="gestionale-driver-selected-label">Driver selezionato</span>
-              <h4 className="gestionale-driver-selected-name">{selectedDriver.firstName ?? '-'} {selectedDriver.lastName ?? '-'}</h4>
+        {selectedDriver && (
+          <article className="dashboard-card gestionale-driver-selected-card">
+            <div className="gestionale-driver-selected-header">
+              <div className="gestionale-driver-selected-title-wrap">
+                <span className="gestionale-driver-selected-label">Driver selezionato</span>
+                <h4 className="gestionale-driver-selected-name">{selectedDriver.firstName ?? '-'} {selectedDriver.lastName ?? '-'}</h4>
+              </div>
+              <div className="gestionale-driver-selected-actions">
+                <button type="button" className="primary-button compact-button" onClick={() => onEditDriver(selectedDriver)}>
+                  <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
+                </button>
+                <button
+                  type="button"
+                  className="gestionale-driver-selected-close"
+                  aria-label="Deseleziona driver"
+                  onClick={() => setSelectedDriverId(null)}
+                >
+                  ×
+                </button>
+              </div>
             </div>
-            <div className="gestionale-driver-selected-actions">
-              <button type="button" className="primary-button compact-button" onClick={() => onEditDriver(selectedDriver)}>
-                <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
-              </button>
-              <button
-                type="button"
-                className="gestionale-driver-selected-close"
-                aria-label="Deseleziona driver"
-                onClick={() => setSelectedDriverId(null)}
-              >
-                ×
-              </button>
-            </div>
-          </div>
 
-          <div className="gestionale-driver-selected-meta-grid">
-            <div className="gestionale-driver-selected-meta-item">
-              <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverMailIcon /></span>
-              <span className="gestionale-driver-selected-meta-value">{selectedDriver.email || '-'}</span>
+            <div className="gestionale-driver-selected-meta-grid">
+              <div className="gestionale-driver-selected-meta-item">
+                <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverMailIcon /></span>
+                <span className="gestionale-driver-selected-meta-value">{selectedDriver.email || '-'}</span>
+              </div>
+              <div className="gestionale-driver-selected-meta-item">
+                <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverPhoneIcon /></span>
+                <span className="gestionale-driver-selected-meta-value">{selectedDriver.mobilePhone || '-'}</span>
+              </div>
+              <div className="gestionale-driver-selected-meta-item">
+                <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverLicenseIcon /></span>
+                <span className="gestionale-driver-selected-meta-value">
+                  {selectedDriver.licenseNumber ?? '-'}
+                  {selectedDriver.licenseTypes?.length ? ` (${selectedDriver.licenseTypes.join(', ')})` : ''}
+                </span>
+              </div>
+              <div className="gestionale-driver-selected-meta-item gestionale-driver-selected-meta-item--address">
+                <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverAddressIcon /></span>
+                <span className="gestionale-driver-selected-meta-value">
+                  {(selectedDriver.residentialAddresses ?? []).join(' | ') || '-'}
+                </span>
+              </div>
             </div>
-            <div className="gestionale-driver-selected-meta-item">
-              <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverPhoneIcon /></span>
-              <span className="gestionale-driver-selected-meta-value">{selectedDriver.mobilePhone || '-'}</span>
-            </div>
-            <div className="gestionale-driver-selected-meta-item">
-              <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverLicenseIcon /></span>
-              <span className="gestionale-driver-selected-meta-value">
-                {selectedDriver.licenseNumber ?? '-'}
-                {selectedDriver.licenseTypes?.length ? ` (${selectedDriver.licenseTypes.join(', ')})` : ''}
-              </span>
-            </div>
-            <div className="gestionale-driver-selected-meta-item gestionale-driver-selected-meta-item--address">
-              <span className="gestionale-driver-selected-meta-icon" aria-hidden="true"><DriverAddressIcon /></span>
-              <span className="gestionale-driver-selected-meta-value">
-                {(selectedDriver.residentialAddresses ?? []).join(' | ') || '-'}
-              </span>
-            </div>
-          </div>
-        </article>
-      )}
+          </article>
+        )}
+      </div>
 
       <article className="dashboard-card gestionale-driver-list-card">
         <div className="panel-header gestionale-driver-toolbar">
@@ -652,31 +680,76 @@ export function GestionaleDriversPanel() {
                       {isExpirySoon && <small className="warning-text">Scade tra {daysLeft} gg</small>}
                     </td>
                     <td>
-                      <div className="table-actions gestionale-driver-table-actions">
-                        <button type="button" className="primary-button compact-button" onClick={() => onSelectDriver(driver)}>
-                          <ButtonContent icon={<SelectIcon />}>Seleziona</ButtonContent>
+                      <div className="services-row-menu">
+                        <button
+                          type="button"
+                          className="services-row-menu-btn"
+                          aria-label={`Azioni driver ${driver.id}`}
+                          title="Azioni"
+                          onClick={(e) => {
+                            const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                            setRowMenuDriverAnchor({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+                            setRowMenuDriverId((prev) => (prev === driver.id ? null : driver.id));
+                          }}
+                        >
+                          ...
                         </button>
-                        <button type="button" className="primary-button compact-button" onClick={() => onEditDriver(driver)}>
-                          <ButtonContent icon={<EditIcon />}>Modifica</ButtonContent>
-                        </button>
-                        {driver.enabled ? (
-                          <button
-                            type="button"
-                            className="primary-button compact-button"
-                            style={{ background: '#d32f2f' }}
-                            onClick={() => onDeleteDriver(driver.id)}
+
+                        {rowMenuDriverId === driver.id && rowMenuDriverAnchor && (
+                          <div
+                            className="services-row-menu-dropdown"
+                            style={{ position: 'fixed', top: `${rowMenuDriverAnchor.top}px`, right: `${rowMenuDriverAnchor.right}px`, zIndex: 9999 }}
                           >
-                            <ButtonContent icon={<DeleteIcon />}>Cancella</ButtonContent>
-                          </button>
-                        ) : (
-                          <button
-                            type="button"
-                            className="primary-button compact-button"
-                            style={{ background: '#7cb342' }}
-                            onClick={() => onRestoreDriver(driver.id)}
-                          >
-                            <ButtonContent icon={<ResetIcon />}>Ripristina</ButtonContent>
-                          </button>
+                            <button
+                              type="button"
+                              className="services-row-menu-item"
+                              onClick={() => {
+                                setRowMenuDriverId(null);
+                                onSelectDriver(driver);
+                              }}
+                            >
+                              <span className="services-row-menu-item-icon"><SelectIcon /></span>
+                              Seleziona
+                            </button>
+
+                            <button
+                              type="button"
+                              className="services-row-menu-item"
+                              onClick={() => {
+                                setRowMenuDriverId(null);
+                                onEditDriver(driver);
+                              }}
+                            >
+                              <span className="services-row-menu-item-icon"><EditIcon /></span>
+                              Modifica
+                            </button>
+
+                            {driver.enabled ? (
+                              <button
+                                type="button"
+                                className="services-row-menu-item"
+                                onClick={() => {
+                                  setRowMenuDriverId(null);
+                                  onDeleteDriver(driver.id);
+                                }}
+                              >
+                                <span className="services-row-menu-item-icon"><DeleteIcon /></span>
+                                Cancella
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                className="services-row-menu-item"
+                                onClick={() => {
+                                  setRowMenuDriverId(null);
+                                  onRestoreDriver(driver.id);
+                                }}
+                              >
+                                <span className="services-row-menu-item-icon"><ResetIcon /></span>
+                                Ripristina
+                              </button>
+                            )}
+                          </div>
                         )}
                       </div>
                     </td>

--- a/frontend/components/login-form.tsx
+++ b/frontend/components/login-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { ButtonContent, LoginIcon } from './action-icons';
 import { PasswordInput } from './password-input';
+import { StatusNotice } from './status-notice';
 
 export function LoginForm() {
   const router = useRouter();
@@ -64,7 +65,7 @@ export function LoginForm() {
         <ButtonContent icon={<LoginIcon />}>{loading ? 'Accesso...' : 'Accedi'}</ButtonContent>
       </button>
 
-      {error && <p className="error-text">{error}</p>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
 
       <p>
         <Link href="/forgot-password">Password dimenticata?</Link>

--- a/frontend/components/reset-password-form.tsx
+++ b/frontend/components/reset-password-form.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ButtonContent, SaveIcon } from './action-icons';
 import { PasswordInput } from './password-input';
+import { StatusNotice } from './status-notice';
 
 export function ResetPasswordForm() {
   const router = useRouter();
@@ -70,8 +71,8 @@ export function ResetPasswordForm() {
         <ButtonContent icon={<SaveIcon />}>{loading ? 'Aggiornamento...' : 'Aggiorna password'}</ButtonContent>
       </button>
 
-      {message && <p className="success-text">{message}</p>}
-      {error && <p className="error-text">{error}</p>}
+      {message && <StatusNotice tone="success">{message}</StatusNotice>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
     </form>
   );
 }

--- a/frontend/components/status-notice.tsx
+++ b/frontend/components/status-notice.tsx
@@ -1,0 +1,78 @@
+import { ReactNode } from 'react';
+
+type StatusNoticeTone = 'info' | 'warning' | 'error' | 'success';
+
+type StatusNoticeProps = {
+  tone: StatusNoticeTone;
+  title?: string;
+  children: ReactNode;
+  className?: string;
+};
+
+function toneRole(tone: StatusNoticeTone) {
+  if (tone === 'error') {
+    return { role: 'alert' as const, live: 'assertive' as const };
+  }
+  return { role: 'status' as const, live: 'polite' as const };
+}
+
+function toneTitle(tone: StatusNoticeTone) {
+  if (tone === 'error') return 'Errore';
+  if (tone === 'warning') return 'Attenzione';
+  if (tone === 'success') return 'Successo';
+  return 'Informazione';
+}
+
+function StatusNoticeIcon({ tone }: { tone: StatusNoticeTone }) {
+  if (tone === 'warning') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M12 3.2 2.8 20h18.4L12 3.2Z" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+        <path d="M12 8.7v5.9" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+        <circle cx="12" cy="17.2" r="1" fill="currentColor" />
+      </svg>
+    );
+  }
+
+  if (tone === 'error') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.8" />
+        <path d="m9.2 9.2 5.6 5.6M14.8 9.2l-5.6 5.6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  if (tone === 'success') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.8" />
+        <path d="m8 12.4 2.6 2.8 5.4-5.8" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M12 10.2v6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <circle cx="12" cy="7.3" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+export function StatusNotice({ tone, title, children, className }: StatusNoticeProps) {
+  const semantics = toneRole(tone);
+  const resolvedTitle = title ?? toneTitle(tone);
+  const classes = ['services-notice', `services-notice--${tone}`, className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes} role={semantics.role} aria-live={semantics.live}>
+      <span className="services-notice-icon" aria-hidden="true"><StatusNoticeIcon tone={tone} /></span>
+      <div className="services-notice-text">
+        <strong className="services-notice-title">{resolvedTitle}</strong>
+        <span>{children}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/finance/components/finance-transactions-table.tsx
+++ b/frontend/features/finance/components/finance-transactions-table.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import { useEffect, useState } from 'react';
 import { formatCurrencyEUR } from '../../../lib/currency';
-import { ButtonContent, CancelIcon, EditIcon } from '../../../components/action-icons';
+import { CancelIcon, EditIcon } from '../../../components/action-icons';
 import { FinancialTransaction } from '../../../types/finance';
+
+function toTitleCase(str: string): string {
+  return str.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 type TableProps = {
   items: FinancialTransaction[];
@@ -11,46 +16,190 @@ type TableProps = {
 };
 
 export function FinanceTransactionsTable({ items, onEdit, onVoid }: TableProps) {
+  const [rowMenuTransactionId, setRowMenuTransactionId] = useState<number | null>(null);
+
+  useEffect(() => {
+    function onDocumentClick(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (target && target.closest('.services-row-menu')) {
+        return;
+      }
+      setRowMenuTransactionId(null);
+    }
+
+    function onDocumentKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setRowMenuTransactionId(null);
+      }
+    }
+
+    document.addEventListener('click', onDocumentClick);
+    document.addEventListener('keydown', onDocumentKeyDown);
+    return () => {
+      document.removeEventListener('click', onDocumentClick);
+      document.removeEventListener('keydown', onDocumentKeyDown);
+    };
+  }, []);
+
+  function getTypeClassName(item: FinancialTransaction) {
+    return item.transactionType === 'RICAVO'
+      ? 'finance-movements-pill finance-movements-pill-revenue'
+      : 'finance-movements-pill finance-movements-pill-cost';
+  }
+
+  function getStatusLabel(item: FinancialTransaction) {
+    if (item.voided) {
+      return 'ANNULLATO';
+    }
+    return item.autoCreated ? 'AUTO' : 'MANUALE';
+  }
+
+  function getStatusClassName(item: FinancialTransaction) {
+    if (item.voided) {
+      return 'finance-movements-pill finance-movements-pill-voided';
+    }
+    return item.autoCreated
+      ? 'finance-movements-pill finance-movements-pill-auto'
+      : 'finance-movements-pill finance-movements-pill-manual';
+  }
+
   return (
-    <div style={{ overflowX: 'auto' }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-        <thead>
-          <tr>
-            <th style={{ textAlign: 'left', borderBottom: '1px solid #dce8f5', padding: '8px 6px' }}>Data</th>
-            <th style={{ textAlign: 'left', borderBottom: '1px solid #dce8f5', padding: '8px 6px' }}>Tipo</th>
-            <th style={{ textAlign: 'left', borderBottom: '1px solid #dce8f5', padding: '8px 6px' }}>Categoria</th>
-            <th style={{ textAlign: 'left', borderBottom: '1px solid #dce8f5', padding: '8px 6px' }}>Descrizione</th>
-            <th style={{ textAlign: 'right', borderBottom: '1px solid #dce8f5', padding: '8px 6px' }}>Importo</th>
-            <th style={{ textAlign: 'left', borderBottom: '1px solid #dce8f5', padding: '8px 6px' }}>Stato</th>
-            <th style={{ textAlign: 'left', borderBottom: '1px solid #dce8f5', padding: '8px 6px' }}>Azioni</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => (
-            <tr key={item.id}>
-              <td style={{ borderBottom: '1px solid #eef4fb', padding: '8px 6px' }}>{item.transactionDate}</td>
-              <td style={{ borderBottom: '1px solid #eef4fb', padding: '8px 6px' }}>{item.transactionType}</td>
-              <td style={{ borderBottom: '1px solid #eef4fb', padding: '8px 6px' }}>{item.category}</td>
-              <td style={{ borderBottom: '1px solid #eef4fb', padding: '8px 6px' }}>{item.description}</td>
-              <td style={{ borderBottom: '1px solid #eef4fb', padding: '8px 6px', textAlign: 'right', color: item.transactionType === 'RICAVO' ? '#1b8a3f' : '#c62828' }}>
-                {formatCurrencyEUR(item.amount)}
-              </td>
-              <td style={{ borderBottom: '1px solid #eef4fb', padding: '8px 6px' }}>
-                {item.voided ? 'ANNULLATO' : item.autoCreated ? 'AUTO' : 'MANUALE'}
-              </td>
-              <td style={{ borderBottom: '1px solid #eef4fb', padding: '8px 6px', display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                <button type="button" className="logout-button" onClick={() => onEdit(item)} disabled={item.voided}><ButtonContent icon={<EditIcon />}>Modifica</ButtonContent></button>
-                <button type="button" className="logout-button" onClick={() => onVoid(item)} disabled={item.voided}><ButtonContent icon={<CancelIcon />}>Annulla</ButtonContent></button>
-              </td>
-            </tr>
-          ))}
-          {items.length === 0 && (
+    <>
+      {/* Desktop table */}
+      <div className="finance-movements-table-wrap finance-movements-desktop-table">
+        <table className="finance-movements-table">
+          <thead>
             <tr>
-              <td colSpan={7} style={{ padding: 12, color: '#4f6b8a' }}>Nessun movimento trovato.</td>
+              <th className="finance-movements-th">Data</th>
+              <th className="finance-movements-th">Tipo</th>
+              <th className="finance-movements-th">Categoria</th>
+              <th className="finance-movements-th">Descrizione</th>
+              <th className="finance-movements-th finance-movements-th-amount">Importo</th>
+              <th className="finance-movements-th">Stato</th>
+              <th className="finance-movements-th finance-movements-th-actions">Azioni</th>
             </tr>
-          )}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id}>
+                <td className="finance-movements-td finance-movements-date">{item.transactionDate}</td>
+                <td className="finance-movements-td">
+                  <span className={getTypeClassName(item)}>{item.transactionType}</span>
+                </td>
+                <td className="finance-movements-td finance-movements-category">{item.category ? toTitleCase(item.category) : ''}</td>
+                <td className="finance-movements-td finance-movements-description">{item.description}</td>
+                <td className="finance-movements-td finance-movements-amount-cell">
+                  <span className={item.transactionType === 'RICAVO' ? 'finance-movements-amount finance-movements-amount-revenue' : 'finance-movements-amount finance-movements-amount-cost'}>
+                    {item.transactionType === 'RICAVO' ? '+' : '-'} {formatCurrencyEUR(Math.abs(item.amount))}
+                  </span>
+                </td>
+                <td className="finance-movements-td">
+                  <span className={getStatusClassName(item)}>{getStatusLabel(item)}</span>
+                </td>
+                <td className="finance-movements-td finance-movements-actions-cell">
+                  <div className="services-row-menu">
+                    <button
+                      type="button"
+                      className="services-row-menu-btn"
+                      aria-label={`Azioni movimento ${item.id}`}
+                      title="Azioni"
+                      onClick={() => setRowMenuTransactionId((prev) => (prev === item.id ? null : item.id))}
+                    >
+                      ...
+                    </button>
+
+                    {rowMenuTransactionId === item.id && (
+                      <div className="services-row-menu-dropdown">
+                        <button
+                          type="button"
+                          className="services-row-menu-item"
+                          onClick={() => {
+                            setRowMenuTransactionId(null);
+                            onEdit(item);
+                          }}
+                          disabled={item.voided}
+                        >
+                          <span className="services-row-menu-item-icon"><EditIcon /></span>
+                          Modifica
+                        </button>
+                        <button
+                          type="button"
+                          className="services-row-menu-item"
+                          onClick={() => {
+                            setRowMenuTransactionId(null);
+                            onVoid(item);
+                          }}
+                          disabled={item.voided}
+                        >
+                          <span className="services-row-menu-item-icon"><CancelIcon /></span>
+                          Annulla
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {items.length === 0 && (
+              <tr>
+                <td colSpan={7} className="finance-movements-empty">Nessun movimento trovato.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile card list */}
+      <div className="finance-movements-mobile-list">
+        {items.length === 0 && (
+          <p className="finance-movements-empty">Nessun movimento trovato.</p>
+        )}
+        {items.map((item) => (
+          <article key={item.id} className={`finance-movement-card${item.voided ? ' is-voided' : ''}`}>
+            <div className="finance-movement-card-top">
+              <div className="finance-movement-card-badges">
+                <span className={getTypeClassName(item)}>{item.transactionType}</span>
+                <span className={getStatusClassName(item)}>{getStatusLabel(item)}</span>
+              </div>
+              <span className={item.transactionType === 'RICAVO' ? 'finance-movements-amount finance-movements-amount-revenue' : 'finance-movements-amount finance-movements-amount-cost'}>
+                {item.transactionType === 'RICAVO' ? '+' : '-'} {formatCurrencyEUR(Math.abs(item.amount))}
+              </span>
+            </div>
+
+            <div className="finance-movement-card-desc">{item.description}</div>
+
+            <div className="finance-movement-card-meta">
+              <span className="finance-movement-card-date">{item.transactionDate}</span>
+              {item.category && (
+                <span className="finance-movement-card-category">{toTitleCase(item.category)}</span>
+              )}
+            </div>
+
+            <div className="finance-movement-card-actions">
+              <button
+                type="button"
+                className="compact-button secondary-button"
+                onClick={() => onEdit(item)}
+                disabled={item.voided}
+                aria-label={`Modifica movimento ${item.id}`}
+              >
+                <span className="button-icon"><EditIcon /></span>
+                <span className="button-label">Modifica</span>
+              </button>
+              <button
+                type="button"
+                className="compact-button logout-button"
+                onClick={() => onVoid(item)}
+                disabled={item.voided}
+                aria-label={`Annulla movimento ${item.id}`}
+              >
+                <span className="button-icon"><CancelIcon /></span>
+                <span className="button-label">Annulla</span>
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </>
   );
 }

--- a/frontend/features/finance/finance-module.tsx
+++ b/frontend/features/finance/finance-module.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from 'react';
-import { AddIcon, ButtonContent, FilterIcon, ResetIcon } from '../../components/action-icons';
+import { AddIcon, ArrowLeftIcon, ArrowRightIcon, ButtonContent, FilterIcon, ResetIcon } from '../../components/action-icons';
 import { StatusNotice } from '../../components/status-notice';
 import { formatCurrencyEUR } from '../../lib/currency';
 import {
@@ -62,6 +62,8 @@ type VehicleListItem = {
   plate: string;
 };
 
+const PAGE_SIZE = 25;
+
 export function FinanceModule({ section = 'overview' }: { section?: 'overview' | 'movements' }) {
   const now = new Date();
   const [year, setYear] = useState(now.getFullYear());
@@ -77,6 +79,7 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
   const [serviceOptions, setServiceOptions] = useState<ServiceFilterOption[]>([]);
   const [vehicleOptions, setVehicleOptions] = useState<VehicleFilterOption[]>([]);
   const [transactions, setTransactions] = useState<FinancialTransaction[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
   const [dashboard, setDashboard] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -264,6 +267,19 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
     );
   }, [dashboard, year]);
 
+  const totalPages = Math.max(1, Math.ceil(transactions.length / PAGE_SIZE));
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const paginatedTransactions = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return transactions.slice(start, start + PAGE_SIZE);
+  }, [transactions, currentPage]);
+
   return (
     <section style={{ display: 'grid', gap: 16 }}>
       <header style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', gap: 10, alignItems: 'center' }}>
@@ -402,11 +418,21 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
                   <option value="asc">Ascendente</option>
                 </select>
               </label>
-              <button type="button" className="primary-button" onClick={loadTransactions}><ButtonContent icon={<FilterIcon />}>Applica filtri</ButtonContent></button>
+              <button
+                type="button"
+                className="primary-button"
+                onClick={() => {
+                  setCurrentPage(1);
+                  loadTransactions();
+                }}
+              >
+                <ButtonContent icon={<FilterIcon />}>Applica filtri</ButtonContent>
+              </button>
               <button
                 type="button"
                 className="logout-button"
                 onClick={() => {
+                  setCurrentPage(1);
                   setFromDate('');
                   setToDate('');
                   setFilterType('');
@@ -454,7 +480,7 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
 
             <div style={{ marginTop: 14 }}>
               <FinanceTransactionsTable
-                items={transactions}
+                items={paginatedTransactions}
                 onEdit={(item) => {
                   setEditing(item);
                   setFormOpen(true);
@@ -462,6 +488,37 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
                 }}
                 onVoid={onVoid}
               />
+            </div>
+
+            <div className="services-list-footer">
+              <div className="services-list-footer-size">
+                <span>Mostra</span>
+                <select className="services-list-pagesize-select" value={PAGE_SIZE} disabled aria-label="Numero risultati per pagina">
+                  <option value={25}>25</option>
+                </select>
+                <span>di {transactions.length} risultati</span>
+              </div>
+              <div className="services-list-footer-pagination">
+                <button
+                  type="button"
+                  className="services-list-page-btn"
+                  onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                  disabled={currentPage === 1}
+                  aria-label="Pagina precedente"
+                >
+                  <ButtonContent icon={<ArrowLeftIcon />}>Prec</ButtonContent>
+                </button>
+                <span className="services-list-page-info">Pagina {currentPage} di {totalPages}</span>
+                <button
+                  type="button"
+                  className="services-list-page-btn"
+                  onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                  disabled={currentPage === totalPages}
+                  aria-label="Pagina successiva"
+                >
+                  <ButtonContent icon={<ArrowRightIcon />}>Succ</ButtonContent>
+                </button>
+              </div>
             </div>
           </article>
         </>

--- a/frontend/features/finance/finance-module.tsx
+++ b/frontend/features/finance/finance-module.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from 'react';
-import { AddIcon, ArrowLeftIcon, ArrowRightIcon, ButtonContent, FilterIcon, ResetIcon } from '../../components/action-icons';
+import { AddIcon, ArrowLeftIcon, ArrowRightIcon, ButtonContent, FilterIcon, SearchIcon } from '../../components/action-icons';
 import { StatusNotice } from '../../components/status-notice';
 import { formatCurrencyEUR } from '../../lib/currency';
 import {
@@ -21,7 +21,7 @@ import { FinanceCategoryDistribution, FinanceMonthlyBars, FinanceYearComparisonC
 import { FinanceSubnav } from './components/finance-subnav';
 import { FinanceTransactionForm } from './components/finance-transaction-form';
 import { FinanceTransactionsTable } from './components/finance-transactions-table';
-
+import { FilterDropdown } from '../../components/filter-dropdown';
 const financeCategories: FinancialTransactionCategory[] = [
   'SERVIZIO',
   'SERVIZIO_ESTERNO',
@@ -40,29 +40,20 @@ const financeCategories: FinancialTransactionCategory[] = [
   'ALTRO_COSTO'
 ];
 
-type ServiceFilterOption = {
-  id: number;
-  label: string;
-};
-
-type VehicleFilterOption = {
-  id: number;
-  label: string;
-};
-
-type ServiceListItem = {
-  id: number;
-  startAt: string;
-  pickupLocation: string;
-  destination: string;
-};
-
-type VehicleListItem = {
-  id: number;
-  plate: string;
-};
+type FinanceStatusFilter = '' | 'AUTO' | 'MANUALE' | 'ANNULLATO';
 
 const PAGE_SIZE = 25;
+
+function toTitleCase(str: string): string {
+  return str.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function getTransactionStatus(item: FinancialTransaction): Exclude<FinanceStatusFilter, ''> {
+  if (item.voided) {
+    return 'ANNULLATO';
+  }
+  return item.autoCreated ? 'AUTO' : 'MANUALE';
+}
 
 export function FinanceModule({ section = 'overview' }: { section?: 'overview' | 'movements' }) {
   const now = new Date();
@@ -71,13 +62,9 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');
   const [filterType, setFilterType] = useState<FinancialTransactionType | ''>('');
+  const [filterStatus, setFilterStatus] = useState<FinanceStatusFilter>('');
   const [filterCategory, setFilterCategory] = useState<FinancialTransactionCategory | ''>('');
-  const [filterServiceId, setFilterServiceId] = useState<number | ''>('');
-  const [filterVehicleId, setFilterVehicleId] = useState<number | ''>('');
-  const [sortBy, setSortBy] = useState<'transactionDate' | 'amount' | 'category'>('transactionDate');
-  const [direction, setDirection] = useState<'asc' | 'desc'>('desc');
-  const [serviceOptions, setServiceOptions] = useState<ServiceFilterOption[]>([]);
-  const [vehicleOptions, setVehicleOptions] = useState<VehicleFilterOption[]>([]);
+  const [descriptionQuery, setDescriptionQuery] = useState('');
   const [transactions, setTransactions] = useState<FinancialTransaction[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [dashboard, setDashboard] = useState<any>(null);
@@ -87,6 +74,7 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
   const [success, setSuccess] = useState<string | null>(null);
   const [editing, setEditing] = useState<FinancialTransaction | null>(null);
   const [formOpen, setFormOpen] = useState(false);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
   const showOverview = section === 'overview';
   const showMovements = section === 'movements';
@@ -115,10 +103,8 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
         toDate: toDate || undefined,
         type: filterType || undefined,
         category: filterCategory || undefined,
-        serviceId: filterServiceId || undefined,
-        vehicleId: filterVehicleId || undefined,
-        sortBy,
-        direction
+        sortBy: 'transactionDate',
+        direction: 'desc'
       });
 
       setTransactions(nextTransactions);
@@ -126,38 +112,6 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
       setError(err instanceof Error ? err.message : 'Errore caricamento movimenti finance');
     } finally {
       setLoading(false);
-    }
-  }
-
-  async function loadFilterOptions() {
-    try {
-      const [servicesResponse, vehiclesResponse] = await Promise.all([
-        fetch('/api/services', { cache: 'no-store' }),
-        fetch('/api/fleet/vehicles', { cache: 'no-store' })
-      ]);
-
-      if (servicesResponse.ok) {
-        const services = (await servicesResponse.json().catch(() => [])) as ServiceListItem[];
-        setServiceOptions(
-          services
-            .map((service) => ({
-              id: service.id,
-              label: `#${service.id} - ${service.pickupLocation} -> ${service.destination} (${new Date(service.startAt).toLocaleDateString('it-IT')})`
-            }))
-            .sort((left, right) => right.id - left.id)
-        );
-      }
-
-      if (vehiclesResponse.ok) {
-        const vehicles = (await vehiclesResponse.json().catch(() => [])) as VehicleListItem[];
-        setVehicleOptions(
-          vehicles
-            .map((vehicle) => ({ id: vehicle.id, label: vehicle.plate }))
-            .sort((left, right) => left.label.localeCompare(right.label))
-        );
-      }
-    } catch {
-      // Options are non-blocking for loading the finance module.
     }
   }
 
@@ -174,9 +128,8 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
       return;
     }
 
-    loadFilterOptions();
     loadTransactions();
-  }, [showMovements]);
+  }, [showMovements, fromDate, toDate, filterType, filterCategory]);
 
   async function onSave(payload: SaveFinancialTransactionPayload) {
     setSubmitting(true);
@@ -267,7 +220,21 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
     );
   }, [dashboard, year]);
 
-  const totalPages = Math.max(1, Math.ceil(transactions.length / PAGE_SIZE));
+  const filteredTransactions = useMemo(() => {
+    const normalizedQuery = descriptionQuery.trim().toLocaleLowerCase();
+
+    return transactions.filter((item) => {
+      if (filterStatus && getTransactionStatus(item) !== filterStatus) {
+        return false;
+      }
+      if (normalizedQuery.length > 0 && !item.description.toLocaleLowerCase().includes(normalizedQuery)) {
+        return false;
+      }
+      return true;
+    });
+  }, [transactions, filterStatus, descriptionQuery]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredTransactions.length / PAGE_SIZE));
 
   useEffect(() => {
     if (currentPage > totalPages) {
@@ -275,10 +242,25 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
     }
   }, [currentPage, totalPages]);
 
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [fromDate, toDate, filterType, filterStatus, filterCategory, descriptionQuery]);
+
   const paginatedTransactions = useMemo(() => {
     const start = (currentPage - 1) * PAGE_SIZE;
-    return transactions.slice(start, start + PAGE_SIZE);
-  }, [transactions, currentPage]);
+    return filteredTransactions.slice(start, start + PAGE_SIZE);
+  }, [filteredTransactions, currentPage]);
+
+  const hasActiveFilters = Boolean(fromDate || toDate || filterType || filterStatus || filterCategory || descriptionQuery.trim());
+
+  function clearAllFilters() {
+    setFromDate('');
+    setToDate('');
+    setFilterType('');
+    setFilterStatus('');
+    setFilterCategory('');
+    setDescriptionQuery('');
+  }
 
   return (
     <section style={{ display: 'grid', gap: 16 }}>
@@ -303,6 +285,19 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
               <input className="form-input" type="number" min={1} max={12} value={month} onChange={(event) => setMonth(Number(event.target.value))} />
             </label>
           </div>
+        )}
+
+        {showMovements && (
+          <button
+            type="button"
+            className="primary-button"
+            onClick={() => {
+              setEditing(null);
+              setFormOpen(true);
+            }}
+          >
+            <ButtonContent icon={<AddIcon />}>Nuovo movimento</ButtonContent>
+          </button>
         )}
       </header>
 
@@ -339,144 +334,131 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
 
       {!loading && showMovements && (
         <>
-          <article className="dashboard-card">
-            <h3>Filtri movimenti</h3>
-            <div style={{ display: 'flex', gap: 8, alignItems: 'end', flexWrap: 'wrap' }}>
-              <label>
-                Dal
-                <input type="date" className="form-input" value={fromDate} onChange={(event) => setFromDate(event.target.value)} />
-              </label>
-              <label>
-                Al
-                <input type="date" className="form-input" value={toDate} onChange={(event) => setToDate(event.target.value)} />
-              </label>
-              <label>
-                Tipo
-                <select className="form-input" value={filterType} onChange={(event) => setFilterType(event.target.value as FinancialTransactionType | '')}>
-                  <option value="">Tutti</option>
-                  <option value="RICAVO">Ricavo</option>
-                  <option value="COSTO">Costo</option>
-                </select>
-              </label>
-              <label>
-                Categoria
-                <select
-                  className="form-input"
-                  value={filterCategory}
-                  onChange={(event) => setFilterCategory(event.target.value as FinancialTransactionCategory | '')}
-                >
-                  <option value="">Tutte</option>
-                  {financeCategories.map((category) => (
-                    <option key={category} value={category}>
-                      {category}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Servizio
-                <select
-                  className="form-input"
-                  value={filterServiceId}
-                  onChange={(event) => setFilterServiceId(event.target.value ? Number(event.target.value) : '')}
-                >
-                  <option value="">Tutti</option>
-                  {serviceOptions.map((option) => (
-                    <option key={option.id} value={option.id}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Veicolo
-                <select
-                  className="form-input"
-                  value={filterVehicleId}
-                  onChange={(event) => setFilterVehicleId(event.target.value ? Number(event.target.value) : '')}
-                >
-                  <option value="">Tutti</option>
-                  {vehicleOptions.map((option) => (
-                    <option key={option.id} value={option.id}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Ordina per
-                <select className="form-input" value={sortBy} onChange={(event) => setSortBy(event.target.value as 'transactionDate' | 'amount' | 'category')}>
-                  <option value="transactionDate">Data</option>
-                  <option value="amount">Importo</option>
-                  <option value="category">Categoria</option>
-                </select>
-              </label>
-              <label>
-                Direzione
-                <select className="form-input" value={direction} onChange={(event) => setDirection(event.target.value as 'asc' | 'desc')}>
-                  <option value="desc">Discendente</option>
-                  <option value="asc">Ascendente</option>
-                </select>
-              </label>
+          <article className="dashboard-card finance-movements-filters-card portal-filters-surface">
+            <div className="finance-movements-filters-header">
+              <h3 style={{ margin: 0 }}>Filtri movimenti</h3>
               <button
                 type="button"
-                className="primary-button"
-                onClick={() => {
-                  setCurrentPage(1);
-                  loadTransactions();
-                }}
+                className="finance-movements-filters-toggle"
+                onClick={() => setMobileFiltersOpen((prev) => !prev)}
+                aria-expanded={mobileFiltersOpen}
               >
-                <ButtonContent icon={<FilterIcon />}>Applica filtri</ButtonContent>
-              </button>
-              <button
-                type="button"
-                className="logout-button"
-                onClick={() => {
-                  setCurrentPage(1);
-                  setFromDate('');
-                  setToDate('');
-                  setFilterType('');
-                  setFilterCategory('');
-                  setFilterServiceId('');
-                  setFilterVehicleId('');
-                  setSortBy('transactionDate');
-                  setDirection('desc');
-                  setTimeout(() => loadTransactions(), 0);
-                }}
-              >
-                <ButtonContent icon={<ResetIcon />}>Reset</ButtonContent>
+                <ButtonContent icon={<FilterIcon />}>{mobileFiltersOpen ? 'Nascondi filtri' : 'Mostra filtri'}</ButtonContent>
               </button>
             </div>
+
+            <div className={`finance-movements-filters-body${mobileFiltersOpen ? '' : ' is-hidden-mobile'}`}>
+            <div className="finance-movements-filters-row">
+              <label className="finance-movements-filter-field finance-movements-filter-search">
+                <span className="finance-movements-filter-search-icon" aria-hidden="true"><SearchIcon /></span>
+                <input
+                  type="text"
+                  className="form-input"
+                  value={descriptionQuery}
+                  onChange={(event) => setDescriptionQuery(event.target.value)}
+                  placeholder="Cerca per descrizione..."
+                  aria-label="Ricerca descrizione"
+                />
+              </label>
+
+              <div className="finance-movements-filter-field">
+                <FilterDropdown
+                  label="Tipo"
+                  value={filterType}
+                  options={[
+                    { value: '', label: 'Tipo' },
+                    { value: 'RICAVO', label: 'Ricavo' },
+                    { value: 'COSTO', label: 'Costo' },
+                  ]}
+                  onChange={(v) => setFilterType(v as FinancialTransactionType | '')}
+                />
+              </div>
+
+              <div className="finance-movements-filter-field">
+                <FilterDropdown
+                  label="Stato"
+                  value={filterStatus}
+                  options={[
+                    { value: '', label: 'Stato' },
+                    { value: 'AUTO', label: 'Auto' },
+                    { value: 'MANUALE', label: 'Manuale' },
+                    { value: 'ANNULLATO', label: 'Annullato' },
+                  ]}
+                  onChange={(v) => setFilterStatus(v as FinanceStatusFilter)}
+                />
+              </div>
+
+              <div className="finance-movements-filter-field">
+                <FilterDropdown
+                  label="Categoria"
+                  value={filterCategory}
+                  options={[
+                    { value: '', label: 'Categoria' },
+                    ...financeCategories.map((cat) => ({ value: cat, label: toTitleCase(cat) })),
+                  ]}
+                  onChange={(v) => setFilterCategory(v as FinancialTransactionCategory | '')}
+                />
+              </div>
+            </div>
+
+            <div className="finance-movements-filters-row finance-movements-filters-row-dates">
+              <label className="finance-movements-filter-field">
+                <input type="date" className="form-input" value={fromDate} onChange={(event) => setFromDate(event.target.value)} aria-label="Data inizio" />
+              </label>
+              <label className="finance-movements-filter-field">
+                <input type="date" className="form-input" value={toDate} onChange={(event) => setToDate(event.target.value)} aria-label="Data fine" />
+              </label>
+            </div>
+
+            {hasActiveFilters && (
+              <div className="finance-movements-active-filters">
+                {filterType && (
+                  <button type="button" className="finance-movements-filter-chip" onClick={() => setFilterType('')}>
+                    Tipo: {filterType}
+                    <span aria-hidden="true">×</span>
+                  </button>
+                )}
+                {filterStatus && (
+                  <button type="button" className="finance-movements-filter-chip" onClick={() => setFilterStatus('')}>
+                    Stato: {filterStatus}
+                    <span aria-hidden="true">×</span>
+                  </button>
+                )}
+                {filterCategory && (
+                  <button type="button" className="finance-movements-filter-chip" onClick={() => setFilterCategory('')}>
+                    Categoria: {toTitleCase(filterCategory)}
+                    <span aria-hidden="true">×</span>
+                  </button>
+                )}
+                {fromDate && (
+                  <button type="button" className="finance-movements-filter-chip" onClick={() => setFromDate('')}>
+                    Dal: {fromDate}
+                    <span aria-hidden="true">×</span>
+                  </button>
+                )}
+                {toDate && (
+                  <button type="button" className="finance-movements-filter-chip" onClick={() => setToDate('')}>
+                    Al: {toDate}
+                    <span aria-hidden="true">×</span>
+                  </button>
+                )}
+                {descriptionQuery.trim() && (
+                  <button type="button" className="finance-movements-filter-chip" onClick={() => setDescriptionQuery('')}>
+                    Ricerca: {descriptionQuery.trim()}
+                    <span aria-hidden="true">×</span>
+                  </button>
+                )}
+
+                <button type="button" className="finance-movements-filters-clear-all" onClick={clearAllFilters}>
+                  Pulisci filtri
+                </button>
+              </div>
+            )}
+            </div>{/* end finance-movements-filters-body */}
           </article>
 
           <article className="dashboard-card">
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-              <h3 style={{ margin: 0 }}>Movimenti finanziari</h3>
-              <button
-                type="button"
-                className="primary-button"
-                onClick={() => {
-                  setEditing(null);
-                  setFormOpen(true);
-                }}
-              >
-                <ButtonContent icon={<AddIcon />}>Nuovo movimento</ButtonContent>
-              </button>
-            </div>
-
-            {formOpen && (
-              <div style={{ marginTop: 12 }}>
-                <FinanceTransactionForm
-                  initial={editing}
-                  onSubmit={onSave}
-                  onCancel={() => {
-                    setEditing(null);
-                    setFormOpen(false);
-                  }}
-                  submitting={submitting}
-                />
-              </div>
-            )}
+            <h3 style={{ margin: 0 }}>Movimenti finanziari</h3>
 
             <div style={{ marginTop: 14 }}>
               <FinanceTransactionsTable
@@ -496,7 +478,7 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
                 <select className="services-list-pagesize-select" value={PAGE_SIZE} disabled aria-label="Numero risultati per pagina">
                   <option value={25}>25</option>
                 </select>
-                <span>di {transactions.length} risultati</span>
+                <span>di {filteredTransactions.length} risultati</span>
               </div>
               <div className="services-list-footer-pagination">
                 <button
@@ -521,6 +503,47 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
               </div>
             </div>
           </article>
+
+          {formOpen && (
+            <div
+              className="services-modal-backdrop"
+              role="dialog"
+              aria-modal="true"
+              aria-label={editing ? `Modifica movimento ${editing.id}` : 'Nuovo movimento'}
+              onClick={() => {
+                setEditing(null);
+                setFormOpen(false);
+              }}
+            >
+              <article className="services-modal" onClick={(event) => event.stopPropagation()}>
+                <div className="services-modal-header">
+                  <h3 className="services-modal-title">{editing ? `Modifica movimento #${editing.id}` : 'Nuovo movimento'}</h3>
+                  <button
+                    type="button"
+                    className="services-modal-close"
+                    onClick={() => {
+                      setEditing(null);
+                      setFormOpen(false);
+                    }}
+                    aria-label="Chiudi modale movimento"
+                  >
+                    ×
+                  </button>
+                </div>
+                <div className="services-modal-body">
+                  <FinanceTransactionForm
+                    initial={editing}
+                    onSubmit={onSave}
+                    onCancel={() => {
+                      setEditing(null);
+                      setFormOpen(false);
+                    }}
+                    submitting={submitting}
+                  />
+                </div>
+              </article>
+            </div>
+          )}
         </>
       )}
     </section>

--- a/frontend/features/finance/finance-module.tsx
+++ b/frontend/features/finance/finance-module.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { AddIcon, ButtonContent, FilterIcon, ResetIcon } from '../../components/action-icons';
+import { StatusNotice } from '../../components/status-notice';
 import { formatCurrencyEUR } from '../../lib/currency';
 import {
   createFinanceTransaction,
@@ -291,8 +292,8 @@ export function FinanceModule({ section = 'overview' }: { section?: 'overview' |
 
       <FinanceSubnav active={section} />
 
-      {error && <p className="error-text">{error}</p>}
-      {success && <p className="success-text">{success}</p>}
+      {error && <StatusNotice tone="error">{error}</StatusNotice>}
+      {success && <StatusNotice tone="success">{success}</StatusNotice>}
       {loading && <p>Caricamento dati finanziari...</p>}
 
       {!loading && showOverview && dashboard && (


### PR DESCRIPTION
## Riepilogo modifiche UI

### FilterDropdown
- Componente  riutilizzabile applicato a ,  e 

### /fleet
- Tutti i form CRUD convertiti in modal
- Liste mobile con card stile 
- Filtri collassabili con chip attivi
- `FleetDeadlinesAlerts` visibile solo se ci sono alert

### /gestionale (driver)
- Menu kebab sulle righe della tabella
- Card informative riposizionate sopra la lista
- Font size ridotto nelle card informative

### /partners
- Colonna **Referente** aggiunta (seconda posizione)
- Grassetto solo su **Ragione Sociale**
- Menu kebab con azioni Seleziona / Modifica

### Fix overflow kebab dropdown
- Dropdown renderizzato con `position: fixed` e coordinate calcolate via `getBoundingClientRect()`
- Applicato su `/partners` e `/gestionale` — risolve il clipping da `overflow: hidden` dei container genitori