### PR TITLE
feat: add DISPOSIZIONE service type with optional duration

### DIFF
--- a/backend/src/main/java/com/rideops/services/application/ServiceValidationSupport.java
+++ b/backend/src/main/java/com/rideops/services/application/ServiceValidationSupport.java
@@ -40,7 +40,7 @@ final class ServiceValidationSupport {
         if (type == ServiceType.TOUR && (durationHours == null || durationHours <= 0)) {
             throw new ServiceValidationException("Per TOUR la durata in ore e` obbligatoria");
         }
-        if (type == ServiceType.TRANSFER && durationHours != null && durationHours <= 0) {
+        if ((type == ServiceType.TRANSFER || type == ServiceType.DISPOSIZIONE) && durationHours != null && durationHours <= 0) {
             throw new ServiceValidationException("La durata in ore deve essere positiva quando valorizzata");
         }
     }

--- a/backend/src/main/java/com/rideops/services/domain/ServiceType.java
+++ b/backend/src/main/java/com/rideops/services/domain/ServiceType.java
@@ -2,5 +2,6 @@ package com.rideops.services.domain;
 
 public enum ServiceType {
     TRANSFER,
-    TOUR
+    TOUR,
+    DISPOSIZIONE
 }

--- a/frontend/components/calendar-dashboard.tsx
+++ b/frontend/components/calendar-dashboard.tsx
@@ -7,7 +7,7 @@ import { formatCurrencyEUR } from '../lib/currency';
 import { StatusNotice } from './status-notice';
 
 type ViewMode = 'month' | 'week' | 'day';
-type ServiceType = 'TRANSFER' | 'TOUR';
+type ServiceType = 'TRANSFER' | 'TOUR' | 'DISPOSIZIONE';
 type ServiceStatus = 'OPEN' | 'ASSIGNED' | 'EXECUTED' | 'CLOSED';
 
 type ServiceItem = {
@@ -467,7 +467,9 @@ export function CalendarDashboard({ driverMode = false }: CalendarDashboardProps
   }
 
   function typeLabel(type: ServiceType) {
-    return type === 'TRANSFER' ? 'Transfer' : 'Tour';
+    if (type === 'TRANSFER') return 'Transfer';
+    if (type === 'DISPOSIZIONE') return 'Disposizione';
+    return 'Tour';
   }
 
   function vehicleLabel(vehicleId: number | null) {
@@ -709,6 +711,7 @@ export function CalendarDashboard({ driverMode = false }: CalendarDashboardProps
               <option value="">Tutte</option>
               <option value="TRANSFER">TRANSFER</option>
               <option value="TOUR">TOUR</option>
+              <option value="DISPOSIZIONE">DISPOSIZIONE</option>
             </select>
           </label>
         </div>

--- a/frontend/components/services-panel.tsx
+++ b/frontend/components/services-panel.tsx
@@ -6,7 +6,7 @@ import { createPortal } from 'react-dom';
 import { AddIcon, ArrowLeftIcon, ArrowRightIcon, ButtonContent, CalendarIcon, CancelIcon, CursorIcon, FilterIcon, LockIcon, OpenIcon, PartnerIcon as SharedPartnerIcon, PrintIcon as SharedPrintIcon, ResetIcon, SaveIcon, SearchIcon, SelectIcon, UserIcon } from './action-icons';
 import { formatCurrencyEUR } from '../lib/currency';
 
-type ServiceType = 'TRANSFER' | 'TOUR';
+type ServiceType = 'TRANSFER' | 'TOUR' | 'DISPOSIZIONE';
 type ServiceStatus = 'OPEN' | 'ASSIGNED' | 'EXECUTED' | 'CLOSED';
 type ServiceAssignmentType = 'INTERNAL' | 'OUTSOURCED' | 'INCOMING';
 
@@ -554,6 +554,9 @@ export function ServicesPanel() {
   function typeLabel(type: ServiceType) {
     if (type === 'TRANSFER') {
       return 'Transfer';
+    }
+    if (type === 'DISPOSIZIONE') {
+      return 'Disposizione';
     }
     return 'Tour';
   }
@@ -1276,7 +1279,8 @@ export function ServicesPanel() {
   const typeFilterOptions: FilterOption[] = [
     { value: '', label: 'Tutti' },
     { value: 'TRANSFER', label: 'Transfer' },
-    { value: 'TOUR', label: 'Tour' }
+    { value: 'TOUR', label: 'Tour' },
+    { value: 'DISPOSIZIONE', label: 'Disposizione' }
   ];
 
   const activeFilterChips = [
@@ -2259,6 +2263,7 @@ export function ServicesPanel() {
               >
                 <option value="TRANSFER">TRANSFER</option>
                 <option value="TOUR">TOUR</option>
+                <option value="DISPOSIZIONE">DISPOSIZIONE</option>
               </select>
             </label>
 


### PR DESCRIPTION
## Descrizione
Aggiunta della nuova tipologia di servizio **DISPOSIZIONE**, in cui il Driver è a completa disposizione del cliente.

## Modifiche
- `ServiceType` enum: aggiunto `DISPOSIZIONE`
- `ServiceValidationSupport`: durata opzionale per `DISPOSIZIONE` (se fornita deve essere positiva). Logica `TRANSFER` e `TOUR` invariata.
- `services-panel.tsx` e `calendar-dashboard.tsx`: tipo, label e dropdown aggiornati

## Note
- Nessuna migrazione Flyway necessaria (`service_type` è già `VARCHAR(20)` senza CHECK constraint)
- Retrocompatibile: tutti i test esistenti passano invariati