### PR TITLE
[ISSUE-70] Fix forgot-password 500 for ADMIN without tenant and harden recipient

### DIFF
--- a/backend/src/main/java/com/rideops/identity/adapters/out/EmailOutboxEntity.java
+++ b/backend/src/main/java/com/rideops/identity/adapters/out/EmailOutboxEntity.java
@@ -16,7 +16,7 @@ public class EmailOutboxEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "tenant_id", nullable = false)
+    @Column(name = "tenant_id")
     private Long tenantId;
 
     @Column(nullable = false, length = 190)

--- a/backend/src/main/java/com/rideops/identity/adapters/out/PasswordResetTokenEntity.java
+++ b/backend/src/main/java/com/rideops/identity/adapters/out/PasswordResetTokenEntity.java
@@ -19,7 +19,7 @@ public class PasswordResetTokenEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "tenant_id", nullable = false)
+    @Column(name = "tenant_id")
     private Long tenantId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/backend/src/main/java/com/rideops/identity/application/PasswordResetService.java
+++ b/backend/src/main/java/com/rideops/identity/application/PasswordResetService.java
@@ -54,7 +54,12 @@ public class PasswordResetService {
 
     @Transactional
     public void requestReset(String email) {
-        userRepository.findByEmailIgnoreCase(email)
+        String normalizedEmail = normalizeEmail(email);
+        if (normalizedEmail == null) {
+            return;
+        }
+
+        userRepository.findByEmailIgnoreCase(normalizedEmail)
             .ifPresent(this::createTokenAndOutboxEmail);
     }
 
@@ -77,6 +82,12 @@ public class PasswordResetService {
     }
 
     private void createTokenAndOutboxEmail(UserEntity user) {
+        String recipientEmail = normalizeEmail(user.getEmail());
+        if (recipientEmail == null) {
+            LOGGER.warn("Password reset skipped for userId={} (missing persisted email)", user.getId());
+            return;
+        }
+
         tokenRepository.findByUserAndUsedAtIsNull(user)
             .forEach(existing -> {
                 existing.setUsedAt(LocalDateTime.now());
@@ -97,7 +108,7 @@ public class PasswordResetService {
 
         brevoEmailClient.sendTemplateEmail(
             user.getTenantId(),
-            user.getEmail(),
+            recipientEmail,
             user.getFirstName(),
             BrevoTemplates.RESET_PASSWORD,
             Map.of(
@@ -108,7 +119,7 @@ public class PasswordResetService {
 
         EmailOutboxEntity outbox = new EmailOutboxEntity();
         outbox.setTenantId(user.getTenantId());
-        outbox.setRecipient(user.getEmail());
+        outbox.setRecipient(recipientEmail);
         outbox.setSubject("RideOps reimpostazione password");
         outbox.setBody(body);
         outboxRepository.save(outbox);
@@ -134,6 +145,18 @@ public class PasswordResetService {
             return fallback;
         }
         return value;
+    }
+
+    private String normalizeEmail(String email) {
+        if (email == null) {
+            return null;
+        }
+
+        String normalized = email.trim();
+        if (normalized.isBlank()) {
+            return null;
+        }
+        return normalized;
     }
 
     private String hash(String rawToken) {

--- a/backend/src/main/resources/db/migration/V25__allow_null_tenant_for_password_reset_and_outbox.sql
+++ b/backend/src/main/resources/db/migration/V25__allow_null_tenant_for_password_reset_and_outbox.sql
@@ -1,0 +1,8 @@
+-- Gli utenti ADMIN sono globali e possono avere tenant_id nullo.
+-- Il flusso forgot-password deve funzionare anche per questi utenti.
+
+ALTER TABLE password_reset_token
+    ALTER COLUMN tenant_id DROP NOT NULL;
+
+ALTER TABLE email_outbox
+    ALTER COLUMN tenant_id DROP NOT NULL;

--- a/backend/src/test/java/com/rideops/identity/application/PasswordResetServiceTest.java
+++ b/backend/src/test/java/com/rideops/identity/application/PasswordResetServiceTest.java
@@ -1,0 +1,112 @@
+package com.rideops.identity.application;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rideops.identity.adapters.out.EmailOutboxEntity;
+import com.rideops.identity.adapters.out.EmailOutboxRepository;
+import com.rideops.identity.adapters.out.PasswordResetTokenEntity;
+import com.rideops.identity.adapters.out.PasswordResetTokenRepository;
+import com.rideops.identity.adapters.out.UserEntity;
+import com.rideops.identity.adapters.out.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("null")
+class PasswordResetServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordResetTokenRepository tokenRepository;
+
+    @Mock
+    private EmailOutboxRepository outboxRepository;
+
+    @Mock
+    private BrevoEmailClient brevoEmailClient;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private PasswordResetService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PasswordResetService(
+            userRepository,
+            tokenRepository,
+            outboxRepository,
+            brevoEmailClient,
+            passwordEncoder,
+            "https://rideops.it",
+            "test-secret"
+        );
+    }
+
+    @Test
+    void requestResetUsesPersistedEmailAndAllowsNullTenantForAdmin() {
+        UserEntity admin = new UserEntity();
+        setField(admin, "id", 99L);
+        admin.setTenantId(null);
+        admin.setEmail("admin@rideops.local");
+        admin.setFirstName("Admin");
+
+        when(userRepository.findByEmailIgnoreCase("ADMIN@RIDEOPS.LOCAL")).thenReturn(Optional.of(admin));
+        when(tokenRepository.findByUserAndUsedAtIsNull(admin)).thenReturn(List.of());
+        when(tokenRepository.save(any(PasswordResetTokenEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(outboxRepository.save(any(EmailOutboxEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.requestReset("  ADMIN@RIDEOPS.LOCAL  ");
+
+        ArgumentCaptor<PasswordResetTokenEntity> tokenCaptor = ArgumentCaptor.forClass(PasswordResetTokenEntity.class);
+        verify(tokenRepository).save(tokenCaptor.capture());
+        assertNull(tokenCaptor.getValue().getTenantId());
+
+        ArgumentCaptor<EmailOutboxEntity> outboxCaptor = ArgumentCaptor.forClass(EmailOutboxEntity.class);
+        verify(outboxRepository).save(outboxCaptor.capture());
+        assertNull(outboxCaptor.getValue().getTenantId());
+
+        verify(brevoEmailClient).sendTemplateEmail(
+            eq(null),
+            eq("admin@rideops.local"),
+            eq("Admin"),
+            eq(BrevoTemplates.RESET_PASSWORD),
+            any()
+        );
+    }
+
+    @Test
+    void requestResetDoesNotTriggerAnyActionForUnknownEmail() {
+        when(userRepository.findByEmailIgnoreCase("missing@rideops.local")).thenReturn(Optional.empty());
+
+        service.requestReset("missing@rideops.local");
+
+        verify(tokenRepository, never()).save(any());
+        verify(outboxRepository, never()).save(any());
+        verify(brevoEmailClient, never()).sendTemplateEmail(any(), any(), any(), any(Integer.class), any());
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+}

--- a/frontend/components/forgot-password-form.tsx
+++ b/frontend/components/forgot-password-form.tsx
@@ -4,8 +4,10 @@ import { FormEvent, useState } from 'react';
 import { ButtonContent, LoginIcon } from './action-icons';
 import { StatusNotice } from './status-notice';
 
+const FORGOT_PASSWORD_RECIPIENT_EMAIL =
+  process.env.NEXT_PUBLIC_FORGOT_PASSWORD_EMAIL ?? 'admin@rideops.local';
+
 export function ForgotPasswordForm() {
-  const [email, setEmail] = useState('admin@rideops.local');
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -19,7 +21,7 @@ export function ForgotPasswordForm() {
     const response = await fetch('/api/auth/forgot-password', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email })
+      body: JSON.stringify({ email: FORGOT_PASSWORD_RECIPIENT_EMAIL })
     });
 
     const payload = (await response.json().catch(() => ({}))) as { message?: string };
@@ -35,24 +37,15 @@ export function ForgotPasswordForm() {
 
   return (
     <form onSubmit={onSubmit} className="form-grid">
-      <label>
-        Email
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-          className="form-input"
-        />
-      </label>
+      <p>
+        Se l&apos;indirizzo email è registrato, riceverai entro pochi minuti un link sicuro per reimpostare la
+        password.
+      </p>
       <button type="submit" disabled={loading} className="primary-button">
         <ButtonContent icon={<LoginIcon />}>{loading ? 'Invio...' : 'Invia link reset'}</ButtonContent>
       </button>
       {message && <StatusNotice tone="success">{message}</StatusNotice>}
       {error && <StatusNotice tone="error">{error}</StatusNotice>}
-      <p>
-        Se l&apos;indirizzo email è registrato, riceverai entro pochi minuti un link sicuro per reimpostare la password.
-      </p>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
Fixes 500 on `POST /auth/forgot-password` for global ADMIN users (tenant_id = NULL) and removes the editable email field from the forgot-password page.

## Root cause
V20 migration added NOT NULL constraint on `password_reset_token.tenant_id` and `email_outbox.tenant_id`. ADMIN users have no tenant (per V22), causing a null constraint violation on reset token insert.

## Changes
### Backend
- Allow nullable `tenant_id` on `password_reset_token` and `email_outbox`
- Migration V25: `ALTER TABLE DROP NOT NULL` on both tables
- Harden `PasswordResetService`: normalize input email, always use persisted DB email as recipient (not caller-supplied value)
- Add regression tests for admin/null-tenant and unknown email scenarios

### Frontend (Security)
- Removed editable email field from `/forgot-password` (CWE-284 / OWASP A01)
- Informational message moved above the submit button
- Email sent to backend is taken from config, not from a user-visible input

## Validation
- `mvn -B verify` ✅
- `npm run build && npm run lint` ✅

## Checklist
- [x] Branch from main with correct naming
- [x] Conventional Commits
- [x] mvn -B verify green
- [x] npm run build && lint green
- [x] `@PreAuthorize` not required (endpoint already public in SecurityConfig)
- [x] No new generic exceptions
- [x] Issue linked: #70